### PR TITLE
UI replace muimaterial

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";
 import { useState } from "react";
+import { CssVarsProvider } from "@mui/joy";
+import { theme } from "./utils/UIStyle";
 
 // import pages for routing
 import Homepage from "./pages/Homepage";
@@ -23,6 +25,7 @@ function App() {
   const ProtectedAccountPage = WithAuth(AccountPage);
 
   return (
+    <CssVarsProvider theme={theme}>
       <BrowserRouter>
         <Routes>
           <Route
@@ -99,6 +102,7 @@ function App() {
           />
         </Routes>
       </BrowserRouter>
+    </CssVarsProvider>
   );
 }
 

--- a/frontend/src/components/AddAnotherMealModal.tsx
+++ b/frontend/src/components/AddAnotherMealModal.tsx
@@ -15,6 +15,7 @@ import { v4 as uuidv4 } from "uuid";
 import axios from "axios";
 import { useUser } from "../contexts/UserContext";
 import {
+  Box,
   Button,
   Modal,
   ModalClose,
@@ -148,7 +149,7 @@ const AddAnotherMealModal: React.FC<GPAddAnotherMealProps> = ({
         <ModalClose />
         <DialogContent>
           <div>
-            <Button variant="outlined">I Have My Own Recipe</Button>
+            <Button>I Have My Own Recipe</Button>
             {/* Code Referenced from MUI Documentation: https://mui.com/joy-ui/react-switch/ */}
             <FormControl
               orientation="horizontal"
@@ -173,6 +174,7 @@ const AddAnotherMealModal: React.FC<GPAddAnotherMealProps> = ({
                 }}
               />
             </FormControl>
+            <Box>
             <form className="meal-form" onSubmit={handleSearchSubmit}>
               <FormControl>
                 <FormLabel>Recipe</FormLabel>
@@ -182,20 +184,18 @@ const AddAnotherMealModal: React.FC<GPAddAnotherMealProps> = ({
                   }}
                   onChange={handleRequestChange}
                   value={recipeRequest}
-                  variant="outlined"
                   required
                 />
               </FormControl>
               <Button
                 type="submit"
                 loading={loading}
-                variant="outlined"
                 loadingPosition="start"
               >
                 Find some Recipes!
               </Button>
             </form>
-
+            </Box>
             {/* Display error message if needed */}
             {errorMessage && (
               <ErrorState

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -76,7 +76,6 @@ const AuthForm: React.FC<GPAuthFormEventProps> = ({
             input: { "data-credential": `${AuthenticationFieldEnum.EMAIL}` },
           }}
           onChange={handleAuthInputChange}
-          variant="outlined"
         />
       </FormControl>
       <FormControl>
@@ -92,7 +91,6 @@ const AuthForm: React.FC<GPAuthFormEventProps> = ({
           }}
           value={formData.password}
           onChange={handleAuthInputChange}
-          variant="outlined"
         />
       </FormControl>
       {handleRegistrationSubmit && (
@@ -113,7 +111,7 @@ const AuthForm: React.FC<GPAuthFormEventProps> = ({
           />
         </div>
       )}
-      <Button className="submit-auth" type="submit" variant="outlined">
+      <Button className="submit-auth" type="submit">
         {handleRegistrationSubmit ? "Sign Up!" : "Login!"}
       </Button>
     </form>

--- a/frontend/src/components/AuthenticatePassword.tsx
+++ b/frontend/src/components/AuthenticatePassword.tsx
@@ -24,10 +24,9 @@ const AuthenticatePassword: React.FC<GPPasswordAuthenticationProps> = ({
           }}
           onChange={handleInputChange}
           type="password"
-          variant="outlined"
         />
       </FormControl>
-      <Button type="submit" variant="outlined">
+      <Button type="submit">
         Submit
       </Button>
     </form>

--- a/frontend/src/components/IngredientModal.tsx
+++ b/frontend/src/components/IngredientModal.tsx
@@ -15,11 +15,16 @@ import {
   addIngredientDatabase,
   updateIngredientDatabase,
 } from "../utils/databaseHelpers";
-import { Button, Box, Modal, FormControl, FormLabel, Input, Select, Option } from "@mui/joy";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
-import dayjs from "dayjs";
+import {
+  Button,
+  Box,
+  Modal,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Option,
+} from "@mui/joy";
 
 type GPIngredientModalProps = {
   modalFor: string;
@@ -147,7 +152,7 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
               />
             </FormControl>
           )}
-          <Box sx={{display: "flex", justifyContent: "space-between"}}>
+          <Box sx={{ display: "flex", justifyContent: "space-between" }}>
             <FormControl>
               <FormLabel>Quantity</FormLabel>
               <Input
@@ -200,24 +205,29 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
             </FormControl>
           </Box>
           {modalFor === INGREDIENT_MODAL && (
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
-              <DatePicker
-                sx={{mt: 1.5, mb: 1.5, width: "100%"}}
+            <FormControl>
+              <FormLabel>Expiration Date</FormLabel>
+              <Input
+                sx={{ mt: 1.5, mb: 1.5, width: "100%" }}
+                type="date"
+                slotProps={{
+                  input: {
+                    "data-ingredientfield":
+                      IngredientDataFields.EXPIRATION_DATE,
+                  },
+                }}
                 name={IngredientDataFields.EXPIRATION_DATE}
-                label="Expiration Date"
-                value={
-                  newIngredientData?.expirationDate
-                    ? dayjs(newIngredientData?.expirationDate)
-                    : null
-                }
-                onChange={(newDate) =>
+                value={newIngredientData?.expirationDate ?? ""}
+                onChange={(event) =>
                   dispatch({
-                    type: actions.SET_DATE,
-                    value: newDate?.format("YYYY-MM-DD"),
+                    type: actions.SET_INPUT,
+                    ingredientField: event?.target
+                      .name as keyof GPIngredientDataTypes,
+                    value: event.target.value,
                   })
                 }
               />
-            </LocalizationProvider>
+            </FormControl>
           )}
           {isEditing ? (
             <FormControl>
@@ -252,7 +262,7 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
                   dispatch({
                     type: actions.SET_INPUT,
                     ingredientField: "department",
-                    value: newValue ?? ""
+                    value: newValue ?? "",
                   })
                 }
                 slotProps={{

--- a/frontend/src/components/IngredientModal.tsx
+++ b/frontend/src/components/IngredientModal.tsx
@@ -122,7 +122,6 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
                   },
                 }}
                 value={newIngredientData?.ingredientName}
-                variant="outlined"
               />
             </FormControl>
           ) : (
@@ -145,7 +144,6 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
                   })
                 }
                 value={newIngredientData?.ingredientName}
-                variant="outlined"
               />
             </FormControl>
           )}
@@ -170,7 +168,6 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
                   })
                 }
                 value={newIngredientData?.quantity}
-                variant="outlined"
               />
             </FormControl>
             <FormControl>
@@ -274,7 +271,7 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
               </Select>
             </FormControl>
           )}
-          <Button type="submit" variant="outlined" sx={{ display: "flex", mx: "auto", mt: 2 }}>
+          <Button type="submit" sx={{ display: "flex", mx: "auto", mt: 2 }}>
             {isEditing ? "Edit Ingredient!" : "Add Ingredient!"}
           </Button>
         </form>

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -182,7 +182,6 @@ const AccountPage: React.FC<GPToggleNavBarProps> = ({ navOpen, toggleNav }) => {
               }}
               onChange={handleInputChange}
               value={userEmail ? userEmail : ""}
-              variant="outlined"
             />
           </FormControl>
         </div>

--- a/frontend/src/pages/GroceryList.tsx
+++ b/frontend/src/pages/GroceryList.tsx
@@ -8,7 +8,7 @@ import AppHeader from "../components/AppHeader";
 import GroceryListDepartment from "../components/GroceryListDepartment";
 import { useState, useEffect } from "react";
 import IngredientModal from "../components/IngredientModal";
-import Button from "@mui/material/Button";
+import { Button } from "@mui/joy";
 import { GROCERY_MODAL } from "../utils/constants";
 import TitledListView from "../components/TitledListView";
 import ErrorState from "../components/ErrorState";

--- a/frontend/src/pages/IngredientsPage.tsx
+++ b/frontend/src/pages/IngredientsPage.tsx
@@ -66,7 +66,6 @@ const IngredientsPage: React.FC<GPToggleNavBarProps> = ({
       <section className="ingredient-page-container">
         <Button
           className="add-button"
-          variant="outlined"
           onClick={addIngredientClick}
         >
           Add Ingredient

--- a/frontend/src/pages/IngredientsPage.tsx
+++ b/frontend/src/pages/IngredientsPage.tsx
@@ -7,7 +7,7 @@ import type {
   GPToggleNavBarProps,
   GPErrorMessageTypes,
 } from "../utils/types";
-import Button from "@mui/material/Button";
+import { Button } from "@mui/joy";
 import { INGREDIENT_MODAL } from "../utils/constants";
 import TitledListView from "../components/TitledListView";
 import { v4 as uuidv4 } from "uuid";

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -14,8 +14,7 @@ import AppHeader from "../components/AppHeader";
 import ErrorState from "../components/ErrorState";
 import AuthForm from "../components/AuthForm";
 import { handleAuthInputChange } from "../utils/utils";
-import Button from "@mui/material/Button";
-import Box from "@mui/material/Box";
+import { Button, Box } from "@mui/joy";
 import { useUser } from "../contexts/UserContext";
 
 const LoginPage: React.FC<GPToggleNavBarProps> = ({ navOpen, toggleNav }) => {
@@ -64,7 +63,7 @@ const LoginPage: React.FC<GPToggleNavBarProps> = ({ navOpen, toggleNav }) => {
           )}
           <div className="new-user-section">
             <p>New User?</p>
-            <Button className="submit-auth" onClick={() => navigate("/signup")}>
+            <Button onClick={() => navigate("/signup")}>
               Register for an Account!
             </Button>
           </div>

--- a/frontend/src/pages/NewListPage.tsx
+++ b/frontend/src/pages/NewListPage.tsx
@@ -10,7 +10,7 @@ import MealCard from "../components/MealCard";
 import MealInfoModal from "../components/MealInfoModal";
 import { useState, useEffect } from "react";
 import AddAnotherMealModal from "../components/AddAnotherMealModal";
-import Button from "@mui/material/Button";
+import { Button } from "@mui/joy";
 import TitledListView from "../components/TitledListView";
 import ErrorState from "../components/ErrorState";
 import { useUser } from "../contexts/UserContext";

--- a/frontend/src/pages/SignupForm.tsx
+++ b/frontend/src/pages/SignupForm.tsx
@@ -13,7 +13,7 @@ import AuthForm from "../components/AuthForm";
 import AppHeader from "../components/AppHeader";
 import ErrorState from "../components/ErrorState";
 import { handleAuthInputChange } from "../utils/utils";
-import Box from "@mui/material/Box";
+import { Box } from "@mui/joy";
 import { useUser } from "../contexts/UserContext";
 
 const SignupForm: React.FC<GPToggleNavBarProps> = ({ navOpen, toggleNav }) => {

--- a/frontend/src/utils/UIStyle.ts
+++ b/frontend/src/utils/UIStyle.ts
@@ -1,43 +1,91 @@
 import { extendTheme } from "@mui/joy/styles";
 
 const theme = extendTheme({
-  colorSchemes: {
-    light: {
-      palette: {
-        // affects all Joy components that has `color="primary"` prop.
-        primary: {
-          50: "#fffbeb",
-          100: "#fef3c7",
-          200: "#fde68a",
-          // 300, 400, ..., 800,
-          300: "#fde68a",
-          400: "#fde68a",
-          500: "#fde68a",
-          600: "#fde68a",
-          700: "#fde68a",
-          800: "#fde68a",
-          900: "#78350f",
+  "colorSchemes": {
+    "light": {
+      "palette": {
+        "primary": {
+          "50": "#ecfeff",
+          "100": "#cffafe",
+          "200": "#a5f3fc",
+          "300": "#67e8f9",
+          "400": "#22d3ee",
+          "500": "#06b6d4",
+          "600": "#0891b2",
+          "700": "#0e7490",
+          "800": "#155e75",
+          "900": "#164e63"
         },
-        neutral: {
-          50: "#fffbeb",
-          100: "#fef3c7",
-          200: "#fde68a",
-          // 300, 400, ..., 800,
-          300: "#fde68a",
-          400: "#fde68a",
-          500: "#fde68a",
-          600: "#fde68a",
-          700: "#fde68a",
-          800: "#fde68a",
-          900: "#78350f",
+        "neutral": {
+          "50": "#fafafa",
+          "100": "#f5f5f5",
+          "200": "#e5e5e5",
+          "300": "#d4d4d4",
+          "400": "#a3a3a3",
+          "500": "#737373",
+          "600": "#525252",
+          "700": "#404040",
+          "800": "#262626",
+          "900": "#171717"
         },
-      },
+        "danger": {
+          "50": "#fdf2f8",
+          "100": "#fce7f3",
+          "200": "#fbcfe8",
+          "300": "#f9a8d4",
+          "400": "#f472b6",
+          "500": "#ec4899",
+          "600": "#db2777",
+          "700": "#be185d",
+          "800": "#9d174d",
+          "900": "#831843"
+        },
+        "success": {
+          "50": "#f0fdfa",
+          "100": "#ccfbf1",
+          "200": "#99f6e4",
+          "300": "#5eead4",
+          "400": "#2dd4bf",
+          "500": "#14b8a6",
+          "600": "#0d9488",
+          "700": "#0f766e",
+          "800": "#115e59",
+          "900": "#134e4a"
+        },
+        "warning": {
+          "50": "#fff8e1",
+          "100": "#ffecb3",
+          "200": "#ffe082",
+          "300": "#ffd54f",
+          "400": "#ffca28",
+          "500": "#ffc107",
+          "600": "#ffb300",
+          "700": "#ffa000",
+          "800": "#ff8f00",
+          "900": "#ff6f00"
+        }
+      }
+    },
+    "dark": {
+      "palette": {}
     },
   },
   fontFamily: {
     display: "Inter, var(--joy-fontFamily-fallback)",
     body: "Inter, var(--joy-fontFamily-fallback)",
   },
+  components: {
+    JoyButton: {
+        defaultProps: {
+            variant: "outlined"
+        }
+    },
+    JoyInput: {
+        defaultProps: {
+            variant: "outlined"
+        }
+    }
+  }
 });
 
 const GPModalStyle = {


### PR DESCRIPTION
## Description

<what this pull request is doing>

- Replace all instances of MUI material into MUI Joy components to allow the global css context to apply to all components
- apply global properties to components
- apply a color scheme

<what will be done in later PRs and not included here>

- solidifying the color scheme
- applying further global style properties to components

## Milestones
<the milestones or stories/features that this works towards>

- frontend design, migrating to react components

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
https://mui.com/joy-ui/customization/approaches/#theming
https://mui.com/joy-ui/customization/themed-components/
https://mui.com/joy-ui/customization/theme-builder/

## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>