### PR TITLE
Tc1 event recommendation

### DIFF
--- a/backend/routes/calendarRoutes.ts
+++ b/backend/routes/calendarRoutes.ts
@@ -7,13 +7,15 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 import { isAuthenticated } from "../utils/authMiddleware";
+import { chooseShoppingTime } from "../utils/calendarUtils";
+const SHOPPING_TIME = 60
 
 router.post(
   "/reccomendEvents",
   isAuthenticated,
   async (req: Request, res: Response) => {
     // get parsed list of events from google calendar
-    const { parsedUserEvents, startDate, endDate, REQUESTED_DAYS } = req.body;
+    const { parsedFreeTime } = req.body;
     const userId = req.session.userId;
     try {
       const user = await prisma.User.findUnique({
@@ -29,7 +31,10 @@ router.post(
       }
       // now we have the users list of recipes
       const userSelectedRecipes = user.recipes;
-      res.json("TODO: return list of empty spaces in calendar");
+      // determine reccomended time slots to shop
+      // approximate shopping time to be 1 hour
+      const shoppingTimeOptions = chooseShoppingTime({userFreeTime: parsedFreeTime, shoppingTime: SHOPPING_TIME})
+      res.json(shoppingTimeOptions);
     } catch (error) {
       res.status(500).send("Error finding empty time slots");
     }

--- a/backend/routes/calendarRoutes.ts
+++ b/backend/routes/calendarRoutes.ts
@@ -7,7 +7,7 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 import { isAuthenticated } from "../utils/authMiddleware";
-import { getShoppingTimeOptions, getRecipeTimeOptions } from "../utils/calendarUtils";
+import { getShoppingTimeOptions, getMultipleScheduleOptions } from "../utils/calendarUtils";
 const SHOPPING_TIME = 60
 
 router.post(
@@ -34,8 +34,8 @@ router.post(
       // determine reccomended time slots to shop
       // approximate shopping time to be 1 hour
       const shoppingTimeOptions = getShoppingTimeOptions({userFreeTime: parsedFreeTime, shoppingTime: SHOPPING_TIME})
-      const recipeTimeOptions = getRecipeTimeOptions({userFreeTime: parsedFreeTime, userRecipes: userSelectedRecipes})
-      res.json(recipeTimeOptions);
+      const recipeScheduleOptions = getMultipleScheduleOptions({userFreeTime: parsedFreeTime, userRecipes: userSelectedRecipes})
+      res.json(recipeScheduleOptions);
     } catch (error) {
       res.status(500).send("Error finding empty time slots");
     }

--- a/backend/routes/calendarRoutes.ts
+++ b/backend/routes/calendarRoutes.ts
@@ -7,7 +7,7 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 import { isAuthenticated } from "../utils/authMiddleware";
-import { chooseShoppingTime } from "../utils/calendarUtils";
+import { getShoppingTimeOptions, getRecipeTimeOptions } from "../utils/calendarUtils";
 const SHOPPING_TIME = 60
 
 router.post(
@@ -33,8 +33,9 @@ router.post(
       const userSelectedRecipes = user.recipes;
       // determine reccomended time slots to shop
       // approximate shopping time to be 1 hour
-      const shoppingTimeOptions = chooseShoppingTime({userFreeTime: parsedFreeTime, shoppingTime: SHOPPING_TIME})
-      res.json(shoppingTimeOptions);
+      const shoppingTimeOptions = getShoppingTimeOptions({userFreeTime: parsedFreeTime, shoppingTime: SHOPPING_TIME})
+      const recipeTimeOptions = getRecipeTimeOptions({userFreeTime: parsedFreeTime, userRecipes: userSelectedRecipes})
+      res.json(recipeTimeOptions);
     } catch (error) {
       res.status(500).send("Error finding empty time slots");
     }

--- a/backend/routes/calendarRoutes.ts
+++ b/backend/routes/calendarRoutes.ts
@@ -13,7 +13,7 @@ router.post(
   isAuthenticated,
   async (req: Request, res: Response) => {
     // get parsed list of events from google calendar
-    const { userEvents } = req.body;
+    const { parsedUserEvents, startDate, endDate, REQUESTED_DAYS } = req.body;
     const userId = req.session.userId;
     try {
       const user = await prisma.User.findUnique({
@@ -29,11 +29,9 @@ router.post(
       }
       // now we have the users list of recipes
       const userSelectedRecipes = user.recipes;
-      // add boolean for whether shopping slot has been assigned (ensure shopping slot assigned first)
-      
-      res.json("TODO: return list of empty spaces in calendar")
+      res.json("TODO: return list of empty spaces in calendar");
     } catch (error) {
-        res.status(500).send("Error finding empty time slots")
+      res.status(500).send("Error finding empty time slots");
     }
   }
 );

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -1,0 +1,35 @@
+import { GPUserEventTypes } from "../../frontend/src/utils/types";
+type GPBestTimeType = {
+  userFreeTime: GPUserEventTypes[];
+  shoppingTime: number;
+};
+const chooseShoppingTime = ({ userFreeTime, shoppingTime }: GPBestTimeType) => {
+  // return 3 options for user to choose from
+  // once we hit 3 choices, break out of loop
+  let choices = 0;
+  let eventOptions: GPUserEventTypes[] = [];
+  for (const freeBlock of userFreeTime) {
+    let startTime = new Date(freeBlock.start);
+    let endTime = new Date(freeBlock.end)
+    console.log(startTime)
+    let blockTime = endTime.getTime() - startTime.getTime();
+    while (blockTime >= shoppingTime) {
+      // if block time is greater than event time, then create an event
+      const option = {
+        name: `Option ${choices + 1}`,
+        start: startTime,
+        end: new Date(startTime.getTime() + 1000 * 60 * shoppingTime),
+      };
+      eventOptions = [...eventOptions, option];
+      blockTime -= shoppingTime;
+      startTime = option.end;
+      choices++;
+      if (choices === 3) {
+        return eventOptions;
+      }
+    }
+  }
+  return eventOptions;
+};
+
+export { chooseShoppingTime };

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -1,17 +1,22 @@
-import { GPUserEventTypes } from "../../frontend/src/utils/types";
+import {
+  GPUserEventTypes,
+  GPRecipeDataTypes,
+} from "../../frontend/src/utils/types";
 type GPBestTimeType = {
   userFreeTime: GPUserEventTypes[];
   shoppingTime: number;
 };
-const chooseShoppingTime = ({ userFreeTime, shoppingTime }: GPBestTimeType) => {
+const getShoppingTimeOptions = ({
+  userFreeTime,
+  shoppingTime,
+}: GPBestTimeType) => {
   // return 3 options for user to choose from
   // once we hit 3 choices, break out of loop
   let choices = 0;
   let eventOptions: GPUserEventTypes[] = [];
   for (const freeBlock of userFreeTime) {
     let startTime = new Date(freeBlock.start);
-    let endTime = new Date(freeBlock.end)
-    console.log(startTime)
+    let endTime = new Date(freeBlock.end);
     let blockTime = endTime.getTime() - startTime.getTime();
     while (blockTime >= shoppingTime) {
       // if block time is greater than event time, then create an event
@@ -32,4 +37,57 @@ const chooseShoppingTime = ({ userFreeTime, shoppingTime }: GPBestTimeType) => {
   return eventOptions;
 };
 
-export { chooseShoppingTime };
+type GPRecipeOptionType = GPUserEventTypes & {
+  recipe: GPRecipeDataTypes;
+};
+type GPRecipeEventTypes = {
+  userFreeTime: GPUserEventTypes[];
+  userRecipes: GPRecipeDataTypes[];
+};
+const getRecipeTimeOptions = ({
+  userFreeTime,
+  userRecipes,
+}: GPRecipeEventTypes) => {
+  // cook one recipe per day
+  // TODO loop through number of options we want
+  let eventOptions: GPRecipeOptionType[] = [];
+  let currentDay = new Date(userFreeTime[0].start);
+  for (const recipe of userRecipes) {
+    for (const freeBlock of userFreeTime) {
+      let startTime = new Date(freeBlock.start);
+      let endTime = new Date(freeBlock.end);
+      // check if the blocks end time is before the current day
+      if (endTime.getTime() >= currentDay.getTime()) {
+        let blockTime = (endTime.getTime() - startTime.getTime()) / 60000;
+        if (
+          blockTime >= recipe.readyInMinutes &&
+          (startTime.getHours() >= 17 ||
+            (endTime.getHours() <= 20 && endTime.getHours() >= 16))
+        ) {
+          // block is large enough to fit the required cook time
+          // start time for block is after 5 pm and before 8 (automatic constraint from "alert hours")
+          if (startTime.getHours() <= 17) {
+            startTime.setHours(17, 0, 0, 0);
+          }
+          const cookTimeOption = {
+            name: recipe.recipeTitle,
+            start: startTime,
+            end: new Date(
+              startTime.getTime() + recipe.readyInMinutes * 1000 * 60
+            ),
+            recipe: recipe,
+          };
+          eventOptions = [...eventOptions, cookTimeOption];
+          // eat leftover servings if > 1, dont have to cook till another day
+          currentDay.setDate(startTime.getDate() + recipe.servings);
+          currentDay.setHours(8, 0, 0, 0);
+          // added option to array, go to next recipe
+          break;
+        }
+      }
+    }
+  }
+  return eventOptions;
+};
+
+export { getShoppingTimeOptions, getRecipeTimeOptions };

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -48,8 +48,7 @@ const getRecipeTimeOptions = ({
   userFreeTime,
   userRecipes,
 }: GPRecipeEventTypes) => {
-  // cook one recipe per day
-  // TODO loop through number of options we want
+  // cook one recipe max per day
   let eventOptions: GPRecipeOptionType[] = [];
   let currentDay = new Date(userFreeTime[0].start);
   for (const recipe of userRecipes) {
@@ -90,4 +89,44 @@ const getRecipeTimeOptions = ({
   return eventOptions;
 };
 
-export { getShoppingTimeOptions, getRecipeTimeOptions };
+const NUM_SCHEDULE_OPTIONS = 3;
+
+const getMultipleScheduleOptions = ({
+  userFreeTime,
+  userRecipes,
+}: GPRecipeEventTypes) => {
+  let scheduleOptions: GPRecipeOptionType[][] = [];
+  let freeTimeArray = userFreeTime;
+  let recipeArray = userRecipes;
+  for (let i = 0; i < NUM_SCHEDULE_OPTIONS; i++) {
+    const option = getRecipeTimeOptions({
+      userFreeTime: freeTimeArray,
+      userRecipes: recipeArray,
+    });
+    scheduleOptions = [...scheduleOptions, option];
+    recipeArray = shuffleArray(recipeArray);
+  }
+  return scheduleOptions;
+};
+
+// shuffle algorithm from: https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+const shuffleArray = <T>(array: T[]): T[] => {
+  const shuffledArray = [...array];
+  let currentIndex = shuffledArray.length;
+
+  // While there remain elements to shuffle...
+  while (currentIndex != 0) {
+    // Pick a remaining element...
+    let randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    // And swap it with the current element.
+    [shuffledArray[currentIndex], shuffledArray[randomIndex]] = [
+      shuffledArray[randomIndex],
+      shuffledArray[currentIndex],
+    ];
+  }
+  return shuffledArray;
+};
+
+export { getShoppingTimeOptions, getRecipeTimeOptions, getMultipleScheduleOptions };

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -1,6 +1,0 @@
-import { GPUserEventTypes } from "../../frontend/src/utils/types"
-
-const findFreeSpace = (userEvents: GPUserEventTypes[]) => {
-    // iterate through the array of user events
-    
-}

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -1,0 +1,6 @@
+import { GPUserEventTypes } from "../../frontend/src/utils/types"
+
+const findFreeSpace = (userEvents: GPUserEventTypes[]) => {
+    // iterate through the array of user events
+    
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,4 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";
-import { useState } from "react";
 import { CssVarsProvider } from "@mui/joy";
 import { theme } from "./utils/UIStyle";
 

--- a/frontend/src/components/AddAnotherMealModal.tsx
+++ b/frontend/src/components/AddAnotherMealModal.tsx
@@ -176,7 +176,7 @@ const AddAnotherMealModal: React.FC<GPAddAnotherMealProps> = ({
                 {/* Code Referenced from MUI Documentation: https://mui.com/joy-ui/react-switch/ */}
                 <FormControl
                   orientation="horizontal"
-                  sx={{ width: "20%", justifyContent: "space-between" }}
+                  sx={{ width: "10%", justifyContent: "space-between" }}
                 >
                   <FormLabel>Use Dietary Preferences</FormLabel>
                   <Switch
@@ -200,7 +200,6 @@ const AddAnotherMealModal: React.FC<GPAddAnotherMealProps> = ({
                 </Button>
               </Box>
             </form>
-            <Button>I Have My Own Recipe</Button>
           </Box>
           {/* Display error message if needed */}
           {errorMessage && (
@@ -222,7 +221,7 @@ const AddAnotherMealModal: React.FC<GPAddAnotherMealProps> = ({
             flexDirectionRow={true}
           />
           {/* if search clicked, add a generate more button */}
-          {searchClicked && (
+          {searchClicked && !loading && (
             <Button onClick={handleGenerateMore}>Generate More!</Button>
           )}
         </DialogContent>

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -66,7 +66,7 @@ const ConnectCalendar = () => {
           if (resp.error !== undefined) {
             throw resp;
           }
-          await listUpcomingEvents();
+          await getUserFreeTime();
         },
       });
     }
@@ -84,7 +84,7 @@ const ConnectCalendar = () => {
     } else {
       // Skip display of account chooser and consent dialog for an existing session.
       tokenClient.requestAccessToken({ prompt: "" });
-    listUpcomingEvents();
+      getUserFreeTime();
     }
   }
 
@@ -96,7 +96,7 @@ const ConnectCalendar = () => {
     }
   }
 
-  async function listUpcomingEvents() {
+  async function getUserFreeTime() {
     try {
       const accessToken = gapi.client.getToken().access_token;
       const startDate = new Date();
@@ -117,6 +117,7 @@ const ConnectCalendar = () => {
           },
         }
       );
+      const userTimeZone = response.data.timeZone
       const userEvents = response.data.items;
       // parse events to extract out only needed information
       const parsedUserEvents: GPUserEventTypes[] = parseUserEvents(userEvents);
@@ -127,12 +128,18 @@ const ConnectCalendar = () => {
         endDate,
         REQUESTED_DAYS,
       });
-      const parsedFreeTime = parseFreeTime(freeTimeBlocks)
-      const events = await axios.post(
+      const parsedFreeTime = parseFreeTime(freeTimeBlocks);
+      const reccomendedEvents = await axios.post(
         `${databaseUrl}/calendar/reccomendEvents`,
-        { parsedUserEvents, startDate, endDate, REQUESTED_DAYS },
+        { parsedFreeTime },
         axiosConfig
       );
+      // get back a list of possible options for each event (shopping + each recipe)
+      const eventOptions = reccomendedEvents.data
+      // need to parse through returned events since not in local time
+      // TODO set state variable held within new list to hold the returned list
+
+      // within new list convert to local time zone and present options to user
     } catch (err) {
       return;
     }

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -9,6 +9,9 @@ import { axiosConfig } from "../utils/databaseHelpers";
 
 import type { GPUserEventTypes } from "../utils/types";
 
+// TODO change requested days to have user input, for now we use 1 week
+const REQUESTED_DAYS = 7
+
 // Code adapted from https://developers.google.com/workspace/calendar/api/quickstart/js
 
 const ConnectCalendar = () => {
@@ -94,12 +97,20 @@ const ConnectCalendar = () => {
   async function listUpcomingEvents() {
     try {
       const accessToken = gapi.client.getToken().access_token;
+      const todayDate = new Date();
+      const endDate = new Date(todayDate.getTime() + 1000 * 60 * 60 * 24 * REQUESTED_DAYS)
       const response = await axios.get(
-        "https://www.googleapis.com/calendar/v3/calendars/primary/events?singleEvents=true",
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events",
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },
+          params: {
+            singleEvents: true,
+            orderBy: "startTime",
+            timeMin: todayDate.toISOString(),
+            timeMax: endDate.toISOString()
+          }
         }
       );
     const userEvents = response.data.items
@@ -118,6 +129,7 @@ const ConnectCalendar = () => {
   return (
     <Box>
       <Button onClick={handleAuthClick}>Add to Calendar!</Button>
+      <Button onClick={handleSignoutClick}>Signout</Button>
     </Box>
   );
 };

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -70,6 +70,21 @@ const ConnectCalendar = () => {
         },
       });
     }
+    if (gapiInited && gisInited) {
+      const token = gapi.client.getToken();
+      if (token) {
+        getUserFreeTime();
+      }
+    }
+  }, [gapiInited, gisInited]);
+
+  useEffect(() => {
+    if (gapiInited && gisInited) {
+      const token = gapi.client.getToken();
+      if (token) {
+        getUserFreeTime();
+      }
+    }
   }, [gapiInited, gisInited]);
 
   function handleAuthClick() {
@@ -83,7 +98,6 @@ const ConnectCalendar = () => {
       tokenClient.requestAccessToken({ prompt: "consent" });
     } else {
       // Skip display of account chooser and consent dialog for an existing session.
-      tokenClient.requestAccessToken({ prompt: "" });
       getUserFreeTime();
     }
   }
@@ -117,7 +131,6 @@ const ConnectCalendar = () => {
           },
         }
       );
-      const userTimeZone = response.data.timeZone
       const userEvents = response.data.items;
       // parse events to extract out only needed information
       const parsedUserEvents: GPUserEventTypes[] = parseUserEvents(userEvents);
@@ -135,10 +148,9 @@ const ConnectCalendar = () => {
         axiosConfig
       );
       // get back a list of possible options for each event (shopping + each recipe)
-      const eventOptions = reccomendedEvents.data
-      // need to parse through returned events since not in local time
-      // TODO set state variable held within new list to hold the returned list
-
+      const eventOptions = reccomendedEvents.data;
+      // TODO set state variable held within new-list-page to hold the list of generated event options
+      
       // within new list convert to local time zone and present options to user
     } catch (err) {
       return;

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -11,7 +11,7 @@ import type { GPUserEventTypes } from "../utils/types";
 import { findFreeTime, parseFreeTime } from "../utils/calendarUtils";
 
 // TODO change requested days to have user input
-const REQUESTED_DAYS = 2;
+const REQUESTED_DAYS = 7;
 
 // Code adapted from https://developers.google.com/workspace/calendar/api/quickstart/js
 

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -84,6 +84,7 @@ const ConnectCalendar = () => {
     } else {
       // Skip display of account chooser and consent dialog for an existing session.
       tokenClient.requestAccessToken({ prompt: "" });
+    listUpcomingEvents();
     }
   }
 

--- a/frontend/src/components/MealCard.tsx
+++ b/frontend/src/components/MealCard.tsx
@@ -34,7 +34,7 @@ const MealCard: React.FC<GPMealCardProps> = ({
   };
 
   return (
-    //click on card to view more able to see more information about recipe (ingredients needed, steps, etc)
+    // click on card to view more able to see more information about recipe (ingredients needed, steps, etc)
     <>
       {/* Code referenced from MUI Joy Documentation https://mui.com/joy-ui/react-card/#interactive-card*/}
       <Card

--- a/frontend/src/components/MealInfoModal.tsx
+++ b/frontend/src/components/MealInfoModal.tsx
@@ -27,7 +27,7 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
   recipeInfo,
 }) => {
   return (
-    //click on card to view more able to see more information about recipe (ingredients needed, steps, etc)
+    // click on card to view more able to see more information about recipe (ingredients needed, steps, etc)
     <Modal
       open={modalOpen}
       onClose={handleModalClose}

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -89,7 +89,7 @@ const Homepage = () => {
         </Grid>
         <Box>
           <TitledListView
-            headerList={[{ title: "Upcoming Meals", spacing: 12 }]}
+            headerList={[{ title: "Selected Meals", spacing: 12 }]}
             list={selectedRecipes}
             renderItem={(meal) => (
               <MealCard

--- a/frontend/src/utils/calendarUtils.ts
+++ b/frontend/src/utils/calendarUtils.ts
@@ -1,10 +1,59 @@
 // Parse user events to extract only necessary data
-const parseUserEvents = ( userEventsData: any) => {
-    return userEventsData.map((userEvent: any) => ({
-        event: userEvent.summary,
-        start: userEvent.start.dateTime,
-        end: userEvent.end.dateTime,
-    }))
+const parseUserEvents = (userEventsData: any) => {
+  return userEventsData.map((userEvent: any) => ({
+    event: userEvent.summary,
+    start: new Date(userEvent.start.dateTime),
+    end: new Date(userEvent.end.dateTime),
+  }));
+};
+
+import type { GPUserEventTypes } from "./types";
+
+type GPFreeSpaceTypes = {
+  userEvents: GPUserEventTypes[];
+  startDate: Date;
+  endDate: Date;
+  REQUESTED_DAYS: number;
+};
+
+const findFreeTime = ({
+  userEvents,
+  startDate,
+  endDate,
+}: GPFreeSpaceTypes) => {
+  // create array of available free spaces in a users week
+  let freeSpaces: GPUserEventTypes[] = [];
+  let timePointer = startDate;
+  // loop through events in calendar starting pointer at start date
+  for (const event of userEvents) {
+    if (timePointer.getTime() < event.start.getTime()) {
+      // create an event object to mark the free space
+      const newFreeSpace = {
+        name: "free",
+        start: new Date(timePointer.getTime()),
+        end: new Date(event.start.getTime()),
+      };
+      freeSpaces = [...freeSpaces, newFreeSpace];
+      // move time pointer to the end of the event
+      timePointer = event.end;
+    }
+  }
+  // after last event in list is checked, check to see if there is space between the time pointer to end
+  if (timePointer.getTime() < endDate.getTime()) {
+    const newFreeSpace = {
+      name: "free",
+      start: new Date(timePointer.getTime()),
+      end: new Date(endDate.getTime()),
+    };
+    freeSpaces = [...freeSpaces, newFreeSpace];
+  }
+  return freeSpaces;
+};
+
+// remove free space between certain hours of the day
+const parseFreeTime = (freeSpace: GPUserEventTypes[]) => {
+    // loop through the array of free space
+
 }
 
-export { parseUserEvents }
+export { parseUserEvents, findFreeTime, parseFreeTime };

--- a/frontend/src/utils/calendarUtils.ts
+++ b/frontend/src/utils/calendarUtils.ts
@@ -1,5 +1,3 @@
-import type { GPUserEventTypes } from "./types"
-
 // Parse user events to extract only necessary data
 const parseUserEvents = ( userEventsData: any) => {
     return userEventsData.map((userEvent: any) => ({

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -26,7 +26,6 @@ const GROCERY_MODAL = "grocery-page";
 
 const START_OF_DAY_TIME = 8;
 const END_OF_DAY_TIME = 20;
-const SHOPPING_TIME = 60;
 
 const PreviewConstants = {
   GROCERY: "Grocery List",
@@ -44,5 +43,4 @@ export {
   GROCERY_MODAL,
   START_OF_DAY_TIME,
   END_OF_DAY_TIME,
-  SHOPPING_TIME
 };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -26,6 +26,7 @@ const GROCERY_MODAL = "grocery-page";
 
 const START_OF_DAY_TIME = 8;
 const END_OF_DAY_TIME = 20;
+const SHOPPING_TIME = 60;
 
 const PreviewConstants = {
   GROCERY: "Grocery List",
@@ -42,5 +43,6 @@ export {
   INGREDIENT_MODAL,
   GROCERY_MODAL,
   START_OF_DAY_TIME,
-  END_OF_DAY_TIME
+  END_OF_DAY_TIME,
+  SHOPPING_TIME
 };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -24,6 +24,9 @@ const TOTAL_SEARCH_REQUESTS = 6;
 const INGREDIENT_MODAL = "ingredients-page";
 const GROCERY_MODAL = "grocery-page";
 
+const START_OF_DAY_TIME = 8;
+const END_OF_DAY_TIME = 20;
+
 const PreviewConstants = {
   GROCERY: "Grocery List",
   INGREDIENT: "Ingredients on Hand",
@@ -38,4 +41,6 @@ export {
   TOTAL_SEARCH_REQUESTS,
   INGREDIENT_MODAL,
   GROCERY_MODAL,
+  START_OF_DAY_TIME,
+  END_OF_DAY_TIME
 };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -79,8 +79,8 @@ type GPIngredientApiInfoType = {
 
 type GPUserEventTypes = {
   name: string;
-  startTime: Date;
-  endTime: Date;
+  start: Date;
+  end: Date;
 };
 
 export type {


### PR DESCRIPTION
## Description

<what this pull request is doing>

- implementing a recommendation algorithm where given the users calendar events and selected recipes will recommend event times that are large enough (according to the recipes "ready in minutes" estimation)

How the algorithm works

- keep track of current day
- loops through the users selected recipes
- loops through array of free blocks in users schedule
- check if block is after current day, large enough for the recipes "ready in minutes", and in the evening
- split large blocks of time to create an event in the evening (example: user has a free block from 8 am to 8 pm, suggested cook time will be at 5 pm)
- Add number of days to currentDay according to number of servings in recipe and number of servings that will be eaten per day

Give users 3 options to choose from

- shuffles recipes and re runs the algorithm to give users new order options

what will be done in later PRs and not included here

- ask user how many of each serving will be eaten per day (to take into account leftovers or multiple people in household)
- frontend integration (via modal?) where users can choose schedule and adjust as needed

## Milestones
<the milestones or stories/features that this works towards>

Technical Challenge #1 recommendation algorithm implementation

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries
Calendar API Reference: https://developers.google.com/workspace/calendar/api/v3/reference/events/list
Date object reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
Shuffling an array: https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array

## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>

- Users have a large block of time in schedule (8 am-8pm), don't schedule cooking dinner at 8 am
- Ensuring a free block is not reused
- Incrementing by current day (cook once per day) and reset to start of day, not current time of free block