### PR TITLE
Tc1 frontend present options

### DIFF
--- a/backend/routes/calendarRoutes.ts
+++ b/backend/routes/calendarRoutes.ts
@@ -7,8 +7,11 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 import { isAuthenticated } from "../utils/authMiddleware";
-import { getShoppingTimeOptions, getMultipleScheduleOptions } from "../utils/calendarUtils";
-const SHOPPING_TIME = 60
+import {
+  getShoppingTimeOptions,
+  getMultipleScheduleOptions,
+} from "../utils/calendarUtils";
+const SHOPPING_TIME = 60;
 
 router.post(
   "/reccomendEvents",
@@ -33,8 +36,14 @@ router.post(
       const userSelectedRecipes = user.recipes;
       // determine reccomended time slots to shop
       // approximate shopping time to be 1 hour
-      const shoppingTimeOptions = getShoppingTimeOptions({userFreeTime: parsedFreeTime, shoppingTime: SHOPPING_TIME})
-      const recipeScheduleOptions = getMultipleScheduleOptions({userFreeTime: parsedFreeTime, userRecipes: userSelectedRecipes})
+      const shoppingTimeOptions = getShoppingTimeOptions({
+        userFreeTime: parsedFreeTime,
+        shoppingTime: SHOPPING_TIME,
+      });
+      const recipeScheduleOptions = getMultipleScheduleOptions({
+        userFreeTime: parsedFreeTime,
+        userRecipes: userSelectedRecipes,
+      });
       res.json(recipeScheduleOptions);
     } catch (error) {
       res.status(500).send("Error finding empty time slots");

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -1,7 +1,9 @@
-import {
+import type {
   GPUserEventTypes,
   GPRecipeDataTypes,
+  GPRecipeEventOptionType,
 } from "../../frontend/src/utils/types";
+
 type GPBestTimeType = {
   userFreeTime: GPUserEventTypes[];
   shoppingTime: number;
@@ -37,9 +39,6 @@ const getShoppingTimeOptions = ({
   return eventOptions;
 };
 
-type GPRecipeOptionType = GPUserEventTypes & {
-  recipe: GPRecipeDataTypes;
-};
 type GPRecipeEventTypes = {
   userFreeTime: GPUserEventTypes[];
   userRecipes: GPRecipeDataTypes[];
@@ -49,7 +48,7 @@ const getRecipeTimeOptions = ({
   userRecipes,
 }: GPRecipeEventTypes) => {
   // cook one recipe max per day
-  let eventOptions: GPRecipeOptionType[] = [];
+  let eventOptions: GPRecipeEventOptionType[] = [];
   let currentDay = new Date(userFreeTime[0].start);
   for (const recipe of userRecipes) {
     for (const freeBlock of userFreeTime) {
@@ -95,7 +94,7 @@ const getMultipleScheduleOptions = ({
   userFreeTime,
   userRecipes,
 }: GPRecipeEventTypes) => {
-  let scheduleOptions: GPRecipeOptionType[][] = [];
+  let scheduleOptions: GPRecipeEventOptionType[][] = [];
   let freeTimeArray = userFreeTime;
   let recipeArray = userRecipes;
   for (let i = 0; i < NUM_SCHEDULE_OPTIONS; i++) {
@@ -129,4 +128,8 @@ const shuffleArray = <T>(array: T[]): T[] => {
   return shuffledArray;
 };
 
-export { getShoppingTimeOptions, getRecipeTimeOptions, getMultipleScheduleOptions };
+export {
+  getShoppingTimeOptions,
+  getRecipeTimeOptions,
+  getMultipleScheduleOptions,
+};

--- a/frontend/src/components/CalendarEventOption.tsx
+++ b/frontend/src/components/CalendarEventOption.tsx
@@ -9,6 +9,7 @@ import {
   Button,
 } from "@mui/joy";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import { DaysOfWeek } from "../utils/enum";
 
 const CalendarEventOption = ({
   eventOption,
@@ -28,10 +29,20 @@ const CalendarEventOption = ({
   });
   return (
     <Card sx={{ width: 350 }}>
-      <div>
+      <Box>
         <Typography
           level="title-lg"
           sx={{
+            textAlign: "center",
+            width: "100%",
+          }}
+        >
+          {DaysOfWeek[startDate.getDay()]}
+        </Typography>
+        <Typography
+          level="title-lg"
+          sx={{
+            textAlign: "center",
             textWrap: "nowrap",
             overflow: "hidden",
             whiteSpace: "nowrap",
@@ -40,10 +51,13 @@ const CalendarEventOption = ({
         >
           {recipe.recipeTitle}
         </Typography>
-        <Typography level="body-md">
-          Cook Time: {recipe.readyInMinutes}
-        </Typography>
-      </div>
+        <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between"}}>
+          <Typography level="body-md">
+            Cook Time: {recipe.readyInMinutes}
+          </Typography>
+          <Typography level="body-md">Servings: {recipe.servings}</Typography>
+        </Box>
+      </Box>
       <AspectRatio minHeight="120px" maxHeight="200px">
         <img
           src={recipe.previewImage}

--- a/frontend/src/components/CalendarEventOption.tsx
+++ b/frontend/src/components/CalendarEventOption.tsx
@@ -1,27 +1,48 @@
 import type { GPRecipeEventOptionType } from "../utils/types";
-import { Box, Card, IconButton, CardContent, Typography, AspectRatio, Button } from "@mui/joy";
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import {
+  Box,
+  Card,
+  IconButton,
+  CardContent,
+  Typography,
+  AspectRatio,
+  Button,
+} from "@mui/joy";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 
-const CalendarEventOption = ({eventOption}: {eventOption: GPRecipeEventOptionType}) => {
-    const recipe = eventOption.recipe
-    const startDate = new Date(eventOption.start)
-    const formattedStart = startDate.toLocaleTimeString([], {hour: 'numeric', minute: 'numeric'}).replace("PM", "").replace("AM", "")
-    const endDate = new Date(eventOption.end)
-    const formattedEnd = endDate.toLocaleTimeString([], {hour: 'numeric', minute: 'numeric'})
-    return (
-    <Card sx={{ width: 450 }}>
+const CalendarEventOption = ({
+  eventOption,
+}: {
+  eventOption: GPRecipeEventOptionType;
+}) => {
+  const recipe = eventOption.recipe;
+  const startDate = new Date(eventOption.start);
+  const formattedStart = startDate
+    .toLocaleTimeString([], { hour: "numeric", minute: "numeric" })
+    .replace("PM", "")
+    .replace("AM", "");
+  const endDate = new Date(eventOption.end);
+  const formattedEnd = endDate.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "numeric",
+  });
+  return (
+    <Card sx={{ width: 350 }}>
       <div>
-        <Typography level="title-lg">{recipe.recipeTitle}</Typography>
-        <Typography level="body-md">Cook Time: {recipe.readyInMinutes}</Typography>
-        <IconButton
-          aria-label="Accept Event Reccomendation"
-          variant="plain"
-          color="neutral"
-          size="sm"
-          sx={{ position: 'absolute', top: '0.875rem', right: '0.5rem' }}
+        <Typography
+          level="title-lg"
+          sx={{
+            textWrap: "nowrap",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+          }}
         >
-          <CheckCircleOutlineIcon />
-        </IconButton>
+          {recipe.recipeTitle}
+        </Typography>
+        <Typography level="body-md">
+          Cook Time: {recipe.readyInMinutes}
+        </Typography>
       </div>
       <AspectRatio minHeight="120px" maxHeight="200px">
         <img
@@ -32,21 +53,42 @@ const CalendarEventOption = ({eventOption}: {eventOption: GPRecipeEventOptionTyp
         />
       </AspectRatio>
       <CardContent orientation="horizontal">
-        <div>
-          <Typography level="body-sm">{startDate.toDateString()}</Typography>
-          <Typography sx={{ fontSize: 'lg', fontWeight: 'lg' }}>{formattedStart}- {formattedEnd}</Typography>
-        </div>
-        <Button
-          size="md"
-          color="primary"
-          aria-label="Adjust event recommendation"
-          sx={{ ml: 'auto', alignSelf: 'center', fontWeight: 600 }}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            width: "100%",
+          }}
         >
-          Adjust Time
-        </Button>
+          <Box>
+            <Typography level="body-sm">{startDate.toDateString()}</Typography>
+            <Typography sx={{ fontSize: "lg", fontWeight: "lg" }}>
+              {formattedStart}- {formattedEnd}
+            </Typography>
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <Button
+              size="md"
+              color="primary"
+              aria-label="Adjust event recommendation"
+              sx={{ ml: "auto", alignSelf: "center", fontWeight: 600 }}
+            >
+              Adjust Time
+            </Button>
+            <IconButton
+              aria-label="Accept Event Reccomendation"
+              variant="plain"
+              color="success"
+              size="md"
+            >
+              <CheckCircleOutlineIcon />
+            </IconButton>
+          </Box>
+        </Box>
       </CardContent>
     </Card>
-    )
-}
+  );
+};
 
-export default CalendarEventOption
+export default CalendarEventOption;

--- a/frontend/src/components/CalendarEventOption.tsx
+++ b/frontend/src/components/CalendarEventOption.tsx
@@ -1,0 +1,52 @@
+import type { GPRecipeEventOptionType } from "../utils/types";
+import { Box, Card, IconButton, CardContent, Typography, AspectRatio, Button } from "@mui/joy";
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+
+const CalendarEventOption = ({eventOption}: {eventOption: GPRecipeEventOptionType}) => {
+    const recipe = eventOption.recipe
+    const startDate = new Date(eventOption.start)
+    const formattedStart = startDate.toLocaleTimeString([], {hour: 'numeric', minute: 'numeric'}).replace("PM", "").replace("AM", "")
+    const endDate = new Date(eventOption.end)
+    const formattedEnd = endDate.toLocaleTimeString([], {hour: 'numeric', minute: 'numeric'})
+    return (
+    <Card sx={{ width: 450 }}>
+      <div>
+        <Typography level="title-lg">{recipe.recipeTitle}</Typography>
+        <Typography level="body-md">Cook Time: {recipe.readyInMinutes}</Typography>
+        <IconButton
+          aria-label="Accept Event Reccomendation"
+          variant="plain"
+          color="neutral"
+          size="sm"
+          sx={{ position: 'absolute', top: '0.875rem', right: '0.5rem' }}
+        >
+          <CheckCircleOutlineIcon />
+        </IconButton>
+      </div>
+      <AspectRatio minHeight="120px" maxHeight="200px">
+        <img
+          src={recipe.previewImage}
+          srcSet={recipe.previewImage}
+          loading="lazy"
+          alt=""
+        />
+      </AspectRatio>
+      <CardContent orientation="horizontal">
+        <div>
+          <Typography level="body-sm">{startDate.toDateString()}</Typography>
+          <Typography sx={{ fontSize: 'lg', fontWeight: 'lg' }}>{formattedStart}- {formattedEnd}</Typography>
+        </div>
+        <Button
+          size="md"
+          color="primary"
+          aria-label="Adjust event recommendation"
+          sx={{ ml: 'auto', alignSelf: 'center', fontWeight: 600 }}
+        >
+          Adjust Time
+        </Button>
+      </CardContent>
+    </Card>
+    )
+}
+
+export default CalendarEventOption

--- a/frontend/src/components/CalendarModal.tsx
+++ b/frontend/src/components/CalendarModal.tsx
@@ -1,15 +1,12 @@
-import React from "react";
 import {
   Modal,
-  Sheet,
   ModalClose,
-  Typography,
   ModalDialog,
-  DialogTitle,
   DialogContent,
 } from "@mui/joy";
 import type { GPRecipeEventOptionType } from "../utils/types";
-import CalendarEventOption from "./CalendarEventOption";
+import CalendarOptionGroup from "./CalendarOptionGroup";
+import TitledListView from "./TitledListView";
 
 type GPCalendarModalTypes = {
   modalOpen: boolean;
@@ -31,11 +28,14 @@ const CalendarModal = ({
     >
       <ModalDialog layout="fullscreen">
         <ModalClose variant="plain" sx={{ m: 1 }} />
-        <DialogTitle>Event Suggestions</DialogTitle>
         <DialogContent>
-          {eventOptions && eventOptions[0] && eventOptions[0][0] && (
-            <CalendarEventOption eventOption={eventOptions[0][0]} />
-          )}
+          <TitledListView
+            headerList={[{ title: "Event Option Groups", spacing: 12 }]}
+            list={eventOptions}
+            renderItem={(optionGroup, index) => (
+              <CalendarOptionGroup key={index} eventOptions={optionGroup} groupNum={index + 1} />
+            )}
+          />
         </DialogContent>
       </ModalDialog>
     </Modal>

--- a/frontend/src/components/CalendarModal.tsx
+++ b/frontend/src/components/CalendarModal.tsx
@@ -1,41 +1,43 @@
 import React from "react";
-import { Modal, Sheet, ModalClose, Typography } from "@mui/joy";
+import {
+  Modal,
+  Sheet,
+  ModalClose,
+  Typography,
+  ModalDialog,
+  DialogTitle,
+  DialogContent,
+} from "@mui/joy";
 import type { GPRecipeEventOptionType } from "../utils/types";
+import CalendarEventOption from "./CalendarEventOption";
 
 type GPCalendarModalTypes = {
   modalOpen: boolean;
   toggleModal: () => void;
   eventOptions: GPRecipeEventOptionType[][];
-}
+};
 
-const CalendarModal = ({modalOpen, toggleModal, eventOptions}: GPCalendarModalTypes) => {
+const CalendarModal = ({
+  modalOpen,
+  toggleModal,
+  eventOptions,
+}: GPCalendarModalTypes) => {
   return (
     <Modal
       aria-labelledby="modal-title"
       aria-describedby="modal-desc"
       open={modalOpen}
       onClose={toggleModal}
-      sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
     >
-      <Sheet
-        variant="outlined"
-        sx={{ maxWidth: 500, borderRadius: "md", p: 3, boxShadow: "lg" }}
-      >
+      <ModalDialog layout="fullscreen">
         <ModalClose variant="plain" sx={{ m: 1 }} />
-        <Typography
-          component="h2"
-          id="modal-title"
-          level="h4"
-          textColor="inherit"
-          sx={{ fontWeight: "lg", mb: 1 }}
-        >
-          This is the modal title
-        </Typography>
-        <Typography id="modal-desc" textColor="text.tertiary">
-          Make sure to use <code>aria-labelledby</code> on the modal dialog with
-          an optional <code>aria-describedby</code> attribute.
-        </Typography>
-      </Sheet>
+        <DialogTitle>Event Suggestions</DialogTitle>
+        <DialogContent>
+          {eventOptions && eventOptions[0] && eventOptions[0][0] && (
+            <CalendarEventOption eventOption={eventOptions[0][0]} />
+          )}
+        </DialogContent>
+      </ModalDialog>
     </Modal>
   );
 };

--- a/frontend/src/components/CalendarModal.tsx
+++ b/frontend/src/components/CalendarModal.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Modal, Sheet, ModalClose, Typography } from "@mui/joy";
+import type { GPRecipeEventOptionType } from "../utils/types";
+
+type GPCalendarModalTypes = {
+  modalOpen: boolean;
+  toggleModal: () => void;
+  eventOptions: GPRecipeEventOptionType[][];
+}
+
+const CalendarModal = ({modalOpen, toggleModal, eventOptions}: GPCalendarModalTypes) => {
+  return (
+    <Modal
+      aria-labelledby="modal-title"
+      aria-describedby="modal-desc"
+      open={modalOpen}
+      onClose={toggleModal}
+      sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
+    >
+      <Sheet
+        variant="outlined"
+        sx={{ maxWidth: 500, borderRadius: "md", p: 3, boxShadow: "lg" }}
+      >
+        <ModalClose variant="plain" sx={{ m: 1 }} />
+        <Typography
+          component="h2"
+          id="modal-title"
+          level="h4"
+          textColor="inherit"
+          sx={{ fontWeight: "lg", mb: 1 }}
+        >
+          This is the modal title
+        </Typography>
+        <Typography id="modal-desc" textColor="text.tertiary">
+          Make sure to use <code>aria-labelledby</code> on the modal dialog with
+          an optional <code>aria-describedby</code> attribute.
+        </Typography>
+      </Sheet>
+    </Modal>
+  );
+};
+
+export default CalendarModal;

--- a/frontend/src/components/CalendarOptionGroup.tsx
+++ b/frontend/src/components/CalendarOptionGroup.tsx
@@ -1,0 +1,40 @@
+import { Box, Typography, IconButton } from "@mui/joy";
+import type { GPRecipeEventOptionType } from "../utils/types";
+import CalendarEventOption from "./CalendarEventOption";
+import TitledListView from "./TitledListView";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+
+type GPCalendarOptionGroup = {
+  eventOptions: GPRecipeEventOptionType[];
+  groupNum: number;
+};
+
+const CalendarOptionGroup = ({
+  eventOptions,
+  groupNum,
+}: GPCalendarOptionGroup) => {
+  return (
+    <Box>
+      <Box sx={{display: "flex", alignItems: "center"}}>
+        <Typography>Option Group #{groupNum}</Typography>
+        <IconButton
+          aria-label="Accept Event Group Reccomendation"
+          variant="plain"
+          color="success"
+          size="lg"
+        >
+          <CheckCircleOutlineIcon />
+        </IconButton>
+      </Box>
+      <TitledListView
+        list={eventOptions}
+        renderItem={(event) => (
+          <CalendarEventOption key={event.recipe.apiId} eventOption={event} />
+        )}
+        flexDirectionRow
+      />
+    </Box>
+  );
+};
+
+export default CalendarOptionGroup;

--- a/frontend/src/components/CalendarOptionGroup.tsx
+++ b/frontend/src/components/CalendarOptionGroup.tsx
@@ -15,7 +15,7 @@ const CalendarOptionGroup = ({
 }: GPCalendarOptionGroup) => {
   return (
     <Box>
-      <Box sx={{display: "flex", alignItems: "center"}}>
+      <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between"}}>
         <Typography>Option Group #{groupNum}</Typography>
         <IconButton
           aria-label="Accept Event Group Reccomendation"
@@ -24,6 +24,7 @@ const CalendarOptionGroup = ({
           size="lg"
         >
           <CheckCircleOutlineIcon />
+        <Typography>Accept All</Typography>
         </IconButton>
       </Box>
       <TitledListView

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -7,7 +7,7 @@ const databaseUrl = import.meta.env.VITE_DATABASE_URL;
 import axios from "axios";
 import { axiosConfig } from "../utils/databaseHelpers";
 
-import type { GPUserEventTypes } from "../utils/types";
+import type { GPUserEventTypes, GPRecipeEventOptionType } from "../utils/types";
 import { findFreeTime, parseFreeTime } from "../utils/calendarUtils";
 
 // TODO change requested days to have user input
@@ -15,7 +15,12 @@ const REQUESTED_DAYS = 7;
 
 // Code adapted from https://developers.google.com/workspace/calendar/api/quickstart/js
 
-const ConnectCalendar = () => {
+type GPConnectCalendarTypes = {
+    onClick: () => void
+    setEvents: (data: GPRecipeEventOptionType[][]) => void;
+}
+
+const ConnectCalendar = ({onClick, setEvents}: GPConnectCalendarTypes) => {
   // Discovery doc URL for APIs used by the quickstart
   const DISCOVERY_DOC =
     "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest";
@@ -149,6 +154,8 @@ const ConnectCalendar = () => {
       );
       // get back a list of possible options for each event (shopping + each recipe)
       const eventOptions = reccomendedEvents.data;
+      setEvents(eventOptions)
+      onClick();
       // TODO set state variable held within new-list-page to hold the list of generated event options
       
       // within new list convert to local time zone and present options to user

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -7,7 +7,7 @@ const databaseUrl = import.meta.env.VITE_DATABASE_URL;
 import axios from "axios";
 import { axiosConfig } from "../utils/databaseHelpers";
 
-import type { GPUserEventTypes, GPRecipeEventOptionType } from "../utils/types";
+import type { GPUserEventTypes, GPRecipeEventOptionType, GPRecipeDataTypes } from "../utils/types";
 import { findFreeTime, parseFreeTime } from "../utils/calendarUtils";
 
 // TODO change requested days to have user input
@@ -18,9 +18,10 @@ const REQUESTED_DAYS = 7;
 type GPConnectCalendarTypes = {
     onClick: () => void
     setEvents: (data: GPRecipeEventOptionType[][]) => void;
+    userSelectedRecipes: GPRecipeDataTypes[]
 }
 
-const ConnectCalendar = ({onClick, setEvents}: GPConnectCalendarTypes) => {
+const ConnectCalendar = ({onClick, setEvents, userSelectedRecipes}: GPConnectCalendarTypes) => {
   // Discovery doc URL for APIs used by the quickstart
   const DISCOVERY_DOC =
     "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest";
@@ -149,7 +150,7 @@ const ConnectCalendar = ({onClick, setEvents}: GPConnectCalendarTypes) => {
       const parsedFreeTime = parseFreeTime(freeTimeBlocks);
       const reccomendedEvents = await axios.post(
         `${databaseUrl}/calendar/reccomendEvents`,
-        { parsedFreeTime },
+        { parsedFreeTime, userSelectedRecipes },
         axiosConfig
       );
       // get back a list of possible options for each event (shopping + each recipe)

--- a/frontend/src/components/TitledListView.tsx
+++ b/frontend/src/components/TitledListView.tsx
@@ -9,7 +9,7 @@ type GPHeaderListType = {
 
 type GPTitledListViewProps<T> = {
   list: T[];
-  renderItem: (item: T) => React.ReactNode;
+  renderItem: (item: T, index: number) => React.ReactNode;
   headerList?: GPHeaderListType[];
   flexDirectionRow?: boolean;
   listHeight?: number

--- a/frontend/src/pages/NewListPage.tsx
+++ b/frontend/src/pages/NewListPage.tsx
@@ -2,6 +2,7 @@ import type {
   GPRecipeDataTypes,
   GPErrorMessageTypes,
   GPRecipeIngredientTypes,
+  GPRecipeEventOptionType,
 } from "../utils/types";
 import AppHeader from "../components/AppHeader";
 import MealCard from "../components/MealCard";
@@ -22,6 +23,7 @@ import axios from "axios";
 import { axiosConfig } from "../utils/databaseHelpers";
 import { Box, Button } from "@mui/joy";
 import ConnectCalendar from "../components/ConnectCalendar";
+import CalendarModal from "../components/CalendarModal";
 
 const databaseUrl = import.meta.env.VITE_DATABASE_URL;
 
@@ -36,6 +38,9 @@ const NewListPage = () => {
   );
   const [message, setMessage] = useState<GPErrorMessageTypes>();
   const [loadingList, setLoadingList] = useState(false);
+  const [calendarModalOpen, setCalendarModalOpen] = useState(false);
+  const [calendarEventOptions, setCalendarEventOptions] = useState<GPRecipeEventOptionType[][]>([]);
+
   const { user } = useUser();
   const navigate = useNavigate();
 
@@ -113,7 +118,7 @@ const NewListPage = () => {
             </Button>
             <Button onClick={handleGenerateList}>Make My List</Button>
           </Box>
-          <ConnectCalendar />
+          <ConnectCalendar onClick={() => setCalendarModalOpen((prev) => !prev)} setEvents={setCalendarEventOptions}/>
         </Box>
         <Box>
           <TitledListView
@@ -145,6 +150,7 @@ const NewListPage = () => {
         recipeInfo={recipeInfoModalInfo}
       />
       <LoadingModal modalOpen={loadingList} />
+      <CalendarModal modalOpen={calendarModalOpen} toggleModal={() => setCalendarModalOpen((prev) => !prev)} eventOptions={calendarEventOptions}/>
     </Box>
   );
 };

--- a/frontend/src/pages/NewListPage.tsx
+++ b/frontend/src/pages/NewListPage.tsx
@@ -118,7 +118,7 @@ const NewListPage = () => {
             </Button>
             <Button onClick={handleGenerateList}>Make My List</Button>
           </Box>
-          <ConnectCalendar onClick={() => setCalendarModalOpen((prev) => !prev)} setEvents={setCalendarEventOptions}/>
+          <ConnectCalendar onClick={() => setCalendarModalOpen((prev) => !prev)} setEvents={setCalendarEventOptions} userSelectedRecipes={selectedRecipes}/>
         </Box>
         <Box>
           <TitledListView

--- a/frontend/src/utils/enum.ts
+++ b/frontend/src/utils/enum.ts
@@ -58,4 +58,14 @@ const Departments = [
   "Tea and Coffee",
 ];
 
-export { IngredientUnitOptions, Intolerances, Diets, Departments };
+const DaysOfWeek = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+]
+
+export { IngredientUnitOptions, Intolerances, Diets, Departments, DaysOfWeek };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -83,6 +83,10 @@ type GPUserEventTypes = {
   end: Date;
 };
 
+type GPRecipeEventOptionType = GPUserEventTypes & {
+  recipe: GPRecipeDataTypes;
+};
+
 export type {
   GPAccountInfoTypes,
   GPAuthFormDataTypes,
@@ -95,4 +99,5 @@ export type {
   GPIngredientWithCostInfoTypes,
   GPIngredientApiInfoType,
   GPUserEventTypes,
+  GPRecipeEventOptionType
 };


### PR DESCRIPTION
## Description

<what this pull request is doing>

- Presents to users 3 groups of options depending on the number of servings each recipe contains and free space in calendar
- Buttons to accept all in a group or accept only a single event
- creating frontend display to present to users suggested event times to cook

<what will be done in later PRs and not included here>

- create modal to allow users to adjust events

## Milestones
<the milestones or stories/features that this works towards>

- TC#1 Google Calendar integration, displaying recommendations to the user

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
Date object documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
MUI modal: https://mui.com/joy-ui/react-modal/
MUI Card: https://mui.com/joy-ui/react-card/

## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>

<div>
    <a href="https://www.loom.com/share/9dd706620f66484ebdddcadf67084434">
      <p>Event Options Display - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/9dd706620f66484ebdddcadf67084434">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/9dd706620f66484ebdddcadf67084434-d057418895d84691-full-play.gif">
    </a>
  </div>