### PR TITLE
Tc1 frontend adjust event time

### DIFF
--- a/frontend/src/components/AdjustEventTimeModal.tsx
+++ b/frontend/src/components/AdjustEventTimeModal.tsx
@@ -15,32 +15,54 @@ import { EventTimeEnum } from "../utils/constants";
 
 type GPEventTimeModal = {
   eventInfo: GPRecipeEventOptionType;
-  setEventOptions: (data: GPRecipeEventOptionType) => void;
+  handleTimeSubmit: (data: GPRecipeEventOptionType) => void;
 };
 
 const AdjustEventTimeModal = ({
   eventInfo,
-  setEventOptions,
+  handleTimeSubmit,
 }: GPEventTimeModal) => {
   // Modal code referenced from https://mui.com/joy-ui/react-modal/
   const [open, setOpen] = React.useState<boolean>(false);
   const eventStartTime = new Date(eventInfo.start);
   const eventEndTime = new Date(eventInfo.end);
-  const [start, setStart] = useState(eventStartTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
-  const [end, setEnd] = useState(eventEndTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+  const [start, setStart] = useState(
+    eventStartTime.toLocaleTimeString([], {
+      hour12: false,
+      hour: "numeric",
+      minute: "numeric",
+    })
+  );
+  const [end, setEnd] = useState(
+    eventEndTime.toLocaleTimeString([], {
+      hour12: false,
+      hour: "numeric",
+      minute: "numeric",
+    })
+  );
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { time } = (event.target as HTMLInputElement).dataset;
     const { value } = event.target;
     if (time === EventTimeEnum.START) {
-      eventStartTime.setHours(parseInt(value.substring(0, 2)));
-      eventStartTime.setMinutes(parseInt(value.substring(3)));
-      setStart(eventStartTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+      setStart(value)
     } else if (time === EventTimeEnum.END) {
-      eventEndTime.setHours(parseInt(value.substring(0, 2)));
-      eventEndTime.setMinutes(parseInt(value.substring(3)));
-      setEnd(eventEndTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+      setEnd(value)
     }
+  };
+
+  const onTimeChangeSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    eventStartTime.setHours(parseInt(start.substring(0, 2)));
+    eventStartTime.setMinutes(parseInt(start.substring(3)));
+    eventEndTime.setHours(parseInt(end.substring(0, 2)));
+    eventEndTime.setMinutes(parseInt(end.substring(3)));
+    const updatedEvent = {
+      ...eventInfo,
+      start: eventStartTime,
+      end: eventEndTime,
+    };
+    handleTimeSubmit(updatedEvent)
   };
 
   return (
@@ -74,7 +96,7 @@ const AdjustEventTimeModal = ({
           >
             Adjust Event Time
           </Typography>
-          <form>
+          <form onSubmit={onTimeChangeSubmit}>
             <FormControl>
               <FormLabel>New Start Time</FormLabel>
               <Input
@@ -103,6 +125,9 @@ const AdjustEventTimeModal = ({
                 required
               />
             </FormControl>
+            <Button type="submit" sx={{ display: "flex", mx: "auto", mt: 2 }}>
+              Adjust Time
+            </Button>
           </form>
         </Sheet>
       </Modal>

--- a/frontend/src/components/AdjustEventTimeModal.tsx
+++ b/frontend/src/components/AdjustEventTimeModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { GPRecipeEventOptionType } from "../utils/types";
 import {
   Button,
@@ -10,7 +10,10 @@ import {
   ModalClose,
   Sheet,
   Typography,
+  FormHelperText,
 } from "@mui/joy";
+import InfoOutlined from "@mui/icons-material/InfoOutline";
+
 import { EventTimeEnum } from "../utils/constants";
 
 type GPEventTimeModal = {
@@ -23,9 +26,9 @@ const AdjustEventTimeModal = ({
   handleTimeSubmit,
 }: GPEventTimeModal) => {
   // Modal code referenced from https://mui.com/joy-ui/react-modal/
-  const [open, setOpen] = React.useState<boolean>(false);
   const eventStartTime = new Date(eventInfo.start);
   const eventEndTime = new Date(eventInfo.end);
+  const [open, setOpen] = React.useState<boolean>(false);
   const [start, setStart] = useState(
     eventStartTime.toLocaleTimeString([], {
       hour12: false,
@@ -40,16 +43,21 @@ const AdjustEventTimeModal = ({
       minute: "numeric",
     })
   );
+  const [inputError, setInputError] = useState(false);
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { time } = (event.target as HTMLInputElement).dataset;
     const { value } = event.target;
     if (time === EventTimeEnum.START) {
-      setStart(value)
+      setStart(value);
     } else if (time === EventTimeEnum.END) {
-      setEnd(value)
+      setEnd(value);
     }
   };
+
+  useEffect(() => {
+    setInputError(start > end);
+  }, [start, end]);
 
   const onTimeChangeSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -62,7 +70,7 @@ const AdjustEventTimeModal = ({
       start: eventStartTime,
       end: eventEndTime,
     };
-    handleTimeSubmit(updatedEvent)
+    handleTimeSubmit(updatedEvent);
   };
 
   return (
@@ -97,7 +105,7 @@ const AdjustEventTimeModal = ({
             Adjust Event Time
           </Typography>
           <form onSubmit={onTimeChangeSubmit}>
-            <FormControl>
+            <FormControl error={inputError}>
               <FormLabel>New Start Time</FormLabel>
               <Input
                 type="time"
@@ -111,7 +119,7 @@ const AdjustEventTimeModal = ({
                 required
               />
             </FormControl>
-            <FormControl>
+            <FormControl error={inputError}>
               <FormLabel>New End Time</FormLabel>
               <Input
                 type="time"
@@ -124,8 +132,18 @@ const AdjustEventTimeModal = ({
                 }}
                 required
               />
+              {inputError && (
+                <FormHelperText>
+                  <InfoOutlined />
+                  End time must be after start
+                </FormHelperText>
+              )}
             </FormControl>
-            <Button type="submit" sx={{ display: "flex", mx: "auto", mt: 2 }}>
+            <Button
+              type="submit"
+              disabled={inputError}
+              sx={{ display: "flex", mx: "auto", mt: 2 }}
+            >
               Adjust Time
             </Button>
           </form>

--- a/frontend/src/components/AdjustEventTimeModal.tsx
+++ b/frontend/src/components/AdjustEventTimeModal.tsx
@@ -15,16 +15,18 @@ import {
 import InfoOutlined from "@mui/icons-material/InfoOutline";
 
 import { EventTimeEnum } from "../utils/constants";
+import { useEventRec } from "../contexts/EventRecContext";
 
 type GPEventTimeModal = {
   eventInfo: GPRecipeEventOptionType;
-  handleTimeSubmit: (data: GPRecipeEventOptionType) => void;
+  groupNum: number;
 };
 
 const AdjustEventTimeModal = ({
   eventInfo,
-  handleTimeSubmit,
-}: GPEventTimeModal) => {
+  groupNum,
+}: 
+GPEventTimeModal) => {
   // Modal code referenced from https://mui.com/joy-ui/react-modal/
   const eventStartTime = new Date(eventInfo.start);
   const eventEndTime = new Date(eventInfo.end);
@@ -44,6 +46,7 @@ const AdjustEventTimeModal = ({
     })
   );
   const [inputError, setInputError] = useState(false);
+  const { eventOptions } = useEventRec();
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { time } = (event.target as HTMLInputElement).dataset;
@@ -70,7 +73,14 @@ const AdjustEventTimeModal = ({
       start: eventStartTime,
       end: eventEndTime,
     };
-    handleTimeSubmit(updatedEvent);
+    if (eventOptions) {
+      const updatedEventsGroup = eventOptions[groupNum].map((eventInfo) =>
+        eventInfo.name === updatedEvent.name
+          ? updatedEvent
+          : eventInfo
+      );
+      eventOptions[groupNum] = updatedEventsGroup
+    }
   };
 
   return (

--- a/frontend/src/components/AdjustEventTimeModal.tsx
+++ b/frontend/src/components/AdjustEventTimeModal.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useState } from "react";
+import type { GPRecipeEventOptionType } from "../utils/types";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalClose,
+  Sheet,
+  Typography,
+} from "@mui/joy";
+import { EventTimeEnum } from "../utils/constants";
+
+type GPEventTimeModal = {
+  eventInfo: GPRecipeEventOptionType;
+  setEventOptions: (data: GPRecipeEventOptionType) => void;
+};
+
+const AdjustEventTimeModal = ({
+  eventInfo,
+  setEventOptions,
+}: GPEventTimeModal) => {
+  // Modal code referenced from https://mui.com/joy-ui/react-modal/
+  const [open, setOpen] = React.useState<boolean>(false);
+  const eventStartTime = new Date(eventInfo.start);
+  const eventEndTime = new Date(eventInfo.end);
+  const [start, setStart] = useState(eventStartTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+  const [end, setEnd] = useState(eventEndTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+
+  const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { time } = (event.target as HTMLInputElement).dataset;
+    const { value } = event.target;
+    if (time === EventTimeEnum.START) {
+      eventStartTime.setHours(parseInt(value.substring(0, 2)));
+      eventStartTime.setMinutes(parseInt(value.substring(3)));
+      setStart(eventStartTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+    } else if (time === EventTimeEnum.END) {
+      eventEndTime.setHours(parseInt(value.substring(0, 2)));
+      eventEndTime.setMinutes(parseInt(value.substring(3)));
+      setEnd(eventEndTime.toLocaleTimeString([], { hour12: false, hour: "numeric", minute: "numeric" }))
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <Button
+        size="md"
+        color="primary"
+        aria-label="Adjust event recommendation"
+        sx={{ ml: "auto", alignSelf: "center", fontWeight: 600 }}
+        onClick={() => setOpen(true)}
+      >
+        Adjust Time
+      </Button>
+      <Modal
+        aria-labelledby="adjust-event-time-modal"
+        open={open}
+        onClose={() => setOpen(false)}
+        sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
+      >
+        <Sheet
+          variant="outlined"
+          sx={{ width: 400, borderRadius: "md", p: 3, boxShadow: "lg" }}
+        >
+          <ModalClose variant="plain" sx={{ m: 1 }} />
+          <Typography
+            component="h2"
+            id="modal-title"
+            level="h4"
+            textColor="inherit"
+            sx={{ fontWeight: "lg", mb: 1 }}
+          >
+            Adjust Event Time
+          </Typography>
+          <form>
+            <FormControl>
+              <FormLabel>New Start Time</FormLabel>
+              <Input
+                type="time"
+                onChange={handleTimeChange}
+                value={start}
+                slotProps={{
+                  input: {
+                    "data-time": EventTimeEnum.START,
+                  },
+                }}
+                required
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>New End Time</FormLabel>
+              <Input
+                type="time"
+                onChange={handleTimeChange}
+                value={end}
+                slotProps={{
+                  input: {
+                    "data-time": EventTimeEnum.END,
+                  },
+                }}
+                required
+              />
+            </FormControl>
+          </form>
+        </Sheet>
+      </Modal>
+    </React.Fragment>
+  );
+};
+
+export default AdjustEventTimeModal;

--- a/frontend/src/components/AdjustEventTimeModal.tsx
+++ b/frontend/src/components/AdjustEventTimeModal.tsx
@@ -46,7 +46,7 @@ GPEventTimeModal) => {
     })
   );
   const [inputError, setInputError] = useState(false);
-  const { eventOptions } = useEventRec();
+  const { eventOptions, setEventOptions } = useEventRec();
 
   const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { time } = (event.target as HTMLInputElement).dataset;
@@ -74,12 +74,12 @@ GPEventTimeModal) => {
       end: eventEndTime,
     };
     if (eventOptions) {
-      const updatedEventsGroup = eventOptions[groupNum].map((eventInfo) =>
-        eventInfo.name === updatedEvent.name
-          ? updatedEvent
-          : eventInfo
-      );
-      eventOptions[groupNum] = updatedEventsGroup
+      setEventOptions((prev) => {
+        const updatedEventOptions = [...prev]
+        updatedEventOptions[groupNum] = prev[groupNum].map((eventInfo) => eventInfo.name === updatedEvent.name ? updatedEvent : eventInfo)
+        return updatedEventOptions
+      })
+      setOpen(false)
     }
   };
 

--- a/frontend/src/components/CalendarEventOption.tsx
+++ b/frontend/src/components/CalendarEventOption.tsx
@@ -83,7 +83,7 @@ const CalendarEventOption = ({
             </Typography>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center" }}>
-            <AdjustEventTimeModal eventInfo={eventOption} setEventOptions={() => {}}/>
+            <AdjustEventTimeModal eventInfo={eventOption} handleTimeSubmit={() => {}}/>
             <IconButton
               aria-label="Accept Event Reccomendation"
               variant="plain"

--- a/frontend/src/components/CalendarEventOption.tsx
+++ b/frontend/src/components/CalendarEventOption.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mui/joy";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import { DaysOfWeek } from "../utils/enum";
+import AdjustEventTimeModal from "./AdjustEventTimeModal";
 
 const CalendarEventOption = ({
   eventOption,
@@ -82,14 +83,7 @@ const CalendarEventOption = ({
             </Typography>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center" }}>
-            <Button
-              size="md"
-              color="primary"
-              aria-label="Adjust event recommendation"
-              sx={{ ml: "auto", alignSelf: "center", fontWeight: 600 }}
-            >
-              Adjust Time
-            </Button>
+            <AdjustEventTimeModal eventInfo={eventOption} setEventOptions={() => {}}/>
             <IconButton
               aria-label="Accept Event Reccomendation"
               variant="plain"

--- a/frontend/src/components/CalendarEventOption.tsx
+++ b/frontend/src/components/CalendarEventOption.tsx
@@ -6,17 +6,20 @@ import {
   CardContent,
   Typography,
   AspectRatio,
-  Button,
 } from "@mui/joy";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import { DaysOfWeek } from "../utils/enum";
 import AdjustEventTimeModal from "./AdjustEventTimeModal";
 
+type GPCalendarOption = {
+  eventOption: GPRecipeEventOptionType;
+  groupNum: number
+};
+
 const CalendarEventOption = ({
   eventOption,
-}: {
-  eventOption: GPRecipeEventOptionType;
-}) => {
+  groupNum
+}: GPCalendarOption) => {
   const recipe = eventOption.recipe;
   const startDate = new Date(eventOption.start);
   const formattedStart = startDate
@@ -28,6 +31,7 @@ const CalendarEventOption = ({
     hour: "numeric",
     minute: "numeric",
   });
+
   return (
     <Card sx={{ width: 350 }}>
       <Box>
@@ -52,7 +56,13 @@ const CalendarEventOption = ({
         >
           {recipe.recipeTitle}
         </Typography>
-        <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between"}}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
           <Typography level="body-md">
             Cook Time: {recipe.readyInMinutes}
           </Typography>
@@ -83,7 +93,10 @@ const CalendarEventOption = ({
             </Typography>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center" }}>
-            <AdjustEventTimeModal eventInfo={eventOption} handleTimeSubmit={() => {}}/>
+            <AdjustEventTimeModal
+              eventInfo={eventOption}
+              groupNum={groupNum}
+            />
             <IconButton
               aria-label="Accept Event Reccomendation"
               variant="plain"

--- a/frontend/src/components/CalendarModal.tsx
+++ b/frontend/src/components/CalendarModal.tsx
@@ -4,21 +4,21 @@ import {
   ModalDialog,
   DialogContent,
 } from "@mui/joy";
-import type { GPRecipeEventOptionType } from "../utils/types";
 import CalendarOptionGroup from "./CalendarOptionGroup";
 import TitledListView from "./TitledListView";
+import { useEventRec } from "../contexts/EventRecContext";
+
 
 type GPCalendarModalTypes = {
   modalOpen: boolean;
   toggleModal: () => void;
-  eventOptions: GPRecipeEventOptionType[][];
 };
 
 const CalendarModal = ({
   modalOpen,
   toggleModal,
-  eventOptions,
 }: GPCalendarModalTypes) => {
+  const {eventOptions} = useEventRec()
   return (
     <Modal
       aria-labelledby="modal-title"
@@ -31,7 +31,7 @@ const CalendarModal = ({
         <DialogContent sx={{my: 4}}>
           <TitledListView
             headerList={[{ title: "Event Option Groups", spacing: 12 }]}
-            list={eventOptions}
+            list={eventOptions ?? []}
             renderItem={(optionGroup, index) => (
               <CalendarOptionGroup key={index} eventOptions={optionGroup} groupNum={index + 1} adjustedSuggestion={false} />
             )}

--- a/frontend/src/components/CalendarModal.tsx
+++ b/frontend/src/components/CalendarModal.tsx
@@ -27,13 +27,13 @@ const CalendarModal = ({
       onClose={toggleModal}
     >
       <ModalDialog layout="fullscreen">
-        <ModalClose variant="plain" sx={{ m: 1 }} />
-        <DialogContent>
+        <ModalClose variant="plain" sx={{ zIndex: 2, m: 1 }} />
+        <DialogContent sx={{my: 4}}>
           <TitledListView
             headerList={[{ title: "Event Option Groups", spacing: 12 }]}
             list={eventOptions}
             renderItem={(optionGroup, index) => (
-              <CalendarOptionGroup key={index} eventOptions={optionGroup} groupNum={index + 1} />
+              <CalendarOptionGroup key={index} eventOptions={optionGroup} groupNum={index + 1} adjustedSuggestion={false} />
             )}
           />
         </DialogContent>

--- a/frontend/src/components/CalendarOptionGroup.tsx
+++ b/frontend/src/components/CalendarOptionGroup.tsx
@@ -33,7 +33,7 @@ const CalendarOptionGroup = ({
       <TitledListView
         list={eventOptions}
         renderItem={(event) => (
-          <CalendarEventOption key={event.recipe.apiId} eventOption={event} />
+          <CalendarEventOption key={event.recipe.apiId} eventOption={event} groupNum={groupNum - 1}/>
         )}
         flexDirectionRow
       />

--- a/frontend/src/components/CalendarOptionGroup.tsx
+++ b/frontend/src/components/CalendarOptionGroup.tsx
@@ -7,17 +7,20 @@ import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 type GPCalendarOptionGroup = {
   eventOptions: GPRecipeEventOptionType[];
   groupNum: number;
+  adjustedSuggestion: boolean;
 };
 
 const CalendarOptionGroup = ({
   eventOptions,
   groupNum,
+  adjustedSuggestion,
 }: GPCalendarOptionGroup) => {
   return (
     <Box>
       <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between"}}>
         <Typography>Option Group #{groupNum}</Typography>
         <IconButton
+          disabled={adjustedSuggestion}
           aria-label="Accept Event Group Reccomendation"
           variant="plain"
           color="success"

--- a/frontend/src/components/ConnectCalendar.tsx
+++ b/frontend/src/components/ConnectCalendar.tsx
@@ -7,8 +7,10 @@ const databaseUrl = import.meta.env.VITE_DATABASE_URL;
 import axios from "axios";
 import { axiosConfig } from "../utils/databaseHelpers";
 
-import type { GPUserEventTypes, GPRecipeEventOptionType, GPRecipeDataTypes } from "../utils/types";
+import type { GPUserEventTypes, GPRecipeDataTypes } from "../utils/types";
 import { findFreeTime, parseFreeTime } from "../utils/calendarUtils";
+import { useEventRec } from "../contexts/EventRecContext";  
+
 
 // TODO change requested days to have user input
 const REQUESTED_DAYS = 7;
@@ -16,12 +18,12 @@ const REQUESTED_DAYS = 7;
 // Code adapted from https://developers.google.com/workspace/calendar/api/quickstart/js
 
 type GPConnectCalendarTypes = {
-    onClick: () => void
-    setEvents: (data: GPRecipeEventOptionType[][]) => void;
-    userSelectedRecipes: GPRecipeDataTypes[]
+  onClick: () => void
+  userSelectedRecipes: GPRecipeDataTypes[]
 }
 
-const ConnectCalendar = ({onClick, setEvents, userSelectedRecipes}: GPConnectCalendarTypes) => {
+const ConnectCalendar = ({onClick, userSelectedRecipes}: GPConnectCalendarTypes) => {
+  const { setEventOptions} = useEventRec()
   // Discovery doc URL for APIs used by the quickstart
   const DISCOVERY_DOC =
     "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest";
@@ -155,7 +157,7 @@ const ConnectCalendar = ({onClick, setEvents, userSelectedRecipes}: GPConnectCal
       );
       // get back a list of possible options for each event (shopping + each recipe)
       const eventOptions = reccomendedEvents.data;
-      setEvents(eventOptions)
+      setEventOptions(eventOptions)
       onClick();
       // TODO set state variable held within new-list-page to hold the list of generated event options
       

--- a/frontend/src/components/IngredientModal.tsx
+++ b/frontend/src/components/IngredientModal.tsx
@@ -25,7 +25,7 @@ import {
   Option,
   FormHelperText,
 } from "@mui/joy";
-import InfoOutlined from "@mui/icons-material/InfoOutlined"
+import InfoOutlined from "@mui/icons-material/InfoOutlined";
 
 type GPIngredientModalProps = {
   modalFor: string;
@@ -51,7 +51,7 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
 }) => {
   const { user } = useUser();
   const [message, setMessage] = useState<GPErrorMessageTypes>();
-  const [ingredientInputError, setIngredientInputError] = useState(false)
+  const [ingredientInputError, setIngredientInputError] = useState(false);
 
   const initialIngredientState = ingredientData ?? {
     id: 0,
@@ -95,7 +95,10 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
     if (isEditing) {
       if (ingredientData) {
         if (ingredientData.quantity && ingredientData.quantity <= 0) {
-          setMessage({ error: true, message: "Quantity must be greater than 0"})
+          setMessage({
+            error: true,
+            message: "Quantity must be greater than 0",
+          });
           return;
         }
         const ingredientId = ingredientData.id;
@@ -171,21 +174,22 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
                 }}
                 type="number"
                 onChange={(event) => {
-                  setIngredientInputError(parseFloat(event.target.value) <= 0)
+                  setIngredientInputError(parseFloat(event.target.value) <= 0);
                   dispatch({
                     type: actions.SET_INPUT,
                     ingredientField: event?.target
                       .name as keyof GPIngredientDataTypes,
                     value: event.target.value,
-                  })
-                }
-                }
+                  });
+                }}
                 value={newIngredientData?.quantity}
               />
-              {ingredientInputError && <FormHelperText>
-                <InfoOutlined />
-                    Quantity must be greater than 0
-                </FormHelperText>}
+              {ingredientInputError && (
+                <FormHelperText>
+                  <InfoOutlined />
+                  Quantity must be greater than 0
+                </FormHelperText>
+              )}
             </FormControl>
             <FormControl>
               <FormLabel>Unit</FormLabel>
@@ -294,7 +298,11 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
               </Select>
             </FormControl>
           )}
-          <Button disabled={ingredientInputError} type="submit" sx={{ display: "flex", mx: "auto", mt: 2 }}>
+          <Button
+            disabled={ingredientInputError}
+            type="submit"
+            sx={{ display: "flex", mx: "auto", mt: 2 }}
+          >
             {isEditing ? "Edit Ingredient!" : "Add Ingredient!"}
           </Button>
         </form>

--- a/frontend/src/contexts/EventRecContext.tsx
+++ b/frontend/src/contexts/EventRecContext.tsx
@@ -3,7 +3,7 @@ import type { GPRecipeEventOptionType } from "../utils/types";
 
 type GPEventContextType = {
   eventOptions: GPRecipeEventOptionType[][] | null;
-  setEventOptions: React.Dispatch<React.SetStateAction<null>>;
+  setEventOptions: React.Dispatch<React.SetStateAction<GPRecipeEventOptionType[][]>>;
 };
 
 const EventRecContext = createContext<GPEventContextType>({
@@ -12,7 +12,7 @@ const EventRecContext = createContext<GPEventContextType>({
 });
 
 export const EventRecProvider = ({children}: {children: React.ReactNode}) => {
-    const [eventOptions, setEventOptions] = useState(null);
+    const [eventOptions, setEventOptions] = useState<GPRecipeEventOptionType[][]>([]);
     return (
         <EventRecContext.Provider value={{eventOptions, setEventOptions}}>
             {children}

--- a/frontend/src/contexts/EventRecContext.tsx
+++ b/frontend/src/contexts/EventRecContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useState, useContext } from "react";
+import type { GPRecipeEventOptionType } from "../utils/types";
+
+type GPEventContextType = {
+  eventOptions: GPRecipeEventOptionType[][] | null;
+  setEventOptions: React.Dispatch<React.SetStateAction<null>>;
+};
+
+const EventRecContext = createContext<GPEventContextType>({
+  eventOptions: null,
+  setEventOptions: () => {},
+});
+
+export const EventRecProvider = ({children}: {children: React.ReactNode}) => {
+    const [eventOptions, setEventOptions] = useState(null);
+    return (
+        <EventRecContext.Provider value={{eventOptions, setEventOptions}}>
+            {children}
+        </EventRecContext.Provider>
+    )
+}
+
+export const useEventRec = () => useContext(EventRecContext)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { UserProvider } from "./contexts/UserContext.tsx";
+import { EventRecProvider } from "./contexts/EventRecContext.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <UserProvider>
-      <App />
+      <EventRecProvider>
+        <App />
+      </EventRecProvider>
     </UserProvider>
   </StrictMode>
 );

--- a/frontend/src/pages/NewListPage.tsx
+++ b/frontend/src/pages/NewListPage.tsx
@@ -2,7 +2,6 @@ import type {
   GPRecipeDataTypes,
   GPErrorMessageTypes,
   GPRecipeIngredientTypes,
-  GPRecipeEventOptionType,
 } from "../utils/types";
 import AppHeader from "../components/AppHeader";
 import MealCard from "../components/MealCard";
@@ -25,6 +24,8 @@ import { Box, Button } from "@mui/joy";
 import ConnectCalendar from "../components/ConnectCalendar";
 import CalendarModal from "../components/CalendarModal";
 
+import { useEventRec } from "../contexts/EventRecContext";
+
 const databaseUrl = import.meta.env.VITE_DATABASE_URL;
 
 const NewListPage = () => {
@@ -39,8 +40,6 @@ const NewListPage = () => {
   const [message, setMessage] = useState<GPErrorMessageTypes>();
   const [loadingList, setLoadingList] = useState(false);
   const [calendarModalOpen, setCalendarModalOpen] = useState(false);
-  const [calendarEventOptions, setCalendarEventOptions] = useState<GPRecipeEventOptionType[][]>([]);
-
   const { user } = useUser();
   const navigate = useNavigate();
 
@@ -118,7 +117,7 @@ const NewListPage = () => {
             </Button>
             <Button onClick={handleGenerateList}>Make My List</Button>
           </Box>
-          <ConnectCalendar onClick={() => setCalendarModalOpen((prev) => !prev)} setEvents={setCalendarEventOptions} userSelectedRecipes={selectedRecipes}/>
+          <ConnectCalendar onClick={() => setCalendarModalOpen((prev) => !prev)} userSelectedRecipes={selectedRecipes}/>
         </Box>
         <Box>
           <TitledListView
@@ -150,7 +149,7 @@ const NewListPage = () => {
         recipeInfo={recipeInfoModalInfo}
       />
       <LoadingModal modalOpen={loadingList} />
-      <CalendarModal modalOpen={calendarModalOpen} toggleModal={() => setCalendarModalOpen((prev) => !prev)} eventOptions={calendarEventOptions}/>
+      <CalendarModal modalOpen={calendarModalOpen} toggleModal={() => setCalendarModalOpen((prev) => !prev)}/>
     </Box>
   );
 };

--- a/frontend/src/utils/UIStyle.ts
+++ b/frontend/src/utils/UIStyle.ts
@@ -108,6 +108,11 @@ const theme = extendTheme({
         color: "primary",
       },
     },
+    JoyFormHelperText: {
+      defaultProps: {
+        color: "error"
+      }
+    }
   },
 });
 

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -9,6 +9,11 @@ const AuthenticationFieldEnum = {
   PASSWORD: "password",
 };
 
+const EventTimeEnum = {
+  START: "startTime",
+  END: "endTime"
+}
+
 const IngredientDataFields = {
   DEPARTMENT: "department",
   IMAGE: "image",
@@ -37,6 +42,7 @@ export {
   AuthenticationFieldEnum,
   IngredientDataFields,
   PreviewConstants,
+  EventTimeEnum,
   GROUP_OF_DISPLAYED_CARDS,
   TOTAL_SEARCH_REQUESTS,
   INGREDIENT_MODAL,


### PR DESCRIPTION
## Description

<what this pull request is doing>

- Create an "adjust time" modal allowing the user to adjust the time of a suggested event
    - Update the start and end time of the suggested event in the array
    - Include error handling to disable user from having the start time after the end time
- Implement useContext to keep track of event options to be accessed across multiple layers and prevent passing along state variables and setter functions across many components

what will be done in later PRs and not included here

- Add on click functionality of select event buttons
- Add meal prep preference modal to ask user preferred time ranges
- Add cook time ranges (15 minute intervals) to event suggestion cards for users to choose

## Milestones
<the milestones or stories/features that this works towards>

- TC1 frontend, allowing a user to modify suggestions from recommendation algorithm

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
https://mui.com/joy-ui/react-modal/
https://blog.logrocket.com/how-to-use-react-context-typescript/
https://medium.com/zestgeek/mastering-reacts-usecontext-hook-simplifying-state-management-65894e6dc431

## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
https://ibb.co/XrWDKBvc