### PR TITLE
Tc2 database edit recipe

### DIFF
--- a/backend/prisma/migrations/20250720175847_editing_author/migration.sql
+++ b/backend/prisma/migrations/20250720175847_editing_author/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `editingAuthor` on the `Recipe` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Recipe" DROP COLUMN "editingAuthor",
+ADD COLUMN     "editingAuthorId" INTEGER,
+ADD COLUMN     "editingAuthorName" TEXT NOT NULL DEFAULT '';
+
+-- AddForeignKey
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_editingAuthorId_fkey" FOREIGN KEY ("editingAuthorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250720182739_editing_author/migration.sql
+++ b/backend/prisma/migrations/20250720182739_editing_author/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "Recipe_apiId_key";
+
+-- AlterTable
+ALTER TABLE "Recipe" ALTER COLUMN "editingAuthorName" DROP DEFAULT;

--- a/backend/prisma/migrations/20250720183454_editing_author/migration.sql
+++ b/backend/prisma/migrations/20250720183454_editing_author/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `editingAuthorId` on the `Recipe` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Recipe" DROP CONSTRAINT "Recipe_editingAuthorId_fkey";
+
+-- AlterTable
+ALTER TABLE "Recipe" DROP COLUMN "editingAuthorId",
+ADD COLUMN     "editingAuthorIds" INTEGER NOT NULL DEFAULT -1;
+
+-- AddForeignKey
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_editingAuthorIds_fkey" FOREIGN KEY ("editingAuthorIds") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250720185110_recipe/migration.sql
+++ b/backend/prisma/migrations/20250720185110_recipe/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `editingAuthorIds` on the `Recipe` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Recipe" DROP CONSTRAINT "Recipe_editingAuthorIds_fkey";
+
+-- AlterTable
+ALTER TABLE "Recipe" DROP COLUMN "editingAuthorIds",
+ADD COLUMN     "editingAuthorId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_editingAuthorId_fkey" FOREIGN KEY ("editingAuthorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250720190350_recipe_unique/migration.sql
+++ b/backend/prisma/migrations/20250720190350_recipe_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[apiId,editingAuthorName]` on the table `Recipe` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Recipe_apiId_editingAuthorName_key" ON "Recipe"("apiId", "editingAuthorName");

--- a/backend/prisma/migrations/20250720190821_recipe_unique_id/migration.sql
+++ b/backend/prisma/migrations/20250720190821_recipe_unique_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[apiId,editingAuthorId]` on the table `Recipe` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Recipe_apiId_editingAuthorName_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Recipe_apiId_editingAuthorId_key" ON "Recipe"("apiId", "editingAuthorId");

--- a/backend/prisma/migrations/20250720204439_recipe_id/migration.sql
+++ b/backend/prisma/migrations/20250720204439_recipe_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recipe" ALTER COLUMN "editingAuthorId" SET DEFAULT -1;

--- a/backend/prisma/migrations/20250720204535_recipe_id/migration.sql
+++ b/backend/prisma/migrations/20250720204535_recipe_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recipe" ALTER COLUMN "editingAuthorId" DROP DEFAULT;

--- a/backend/prisma/migrations/20250720211336_apiid/migration.sql
+++ b/backend/prisma/migrations/20250720211336_apiid/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recipe" ALTER COLUMN "apiId" SET DATA TYPE TEXT;

--- a/backend/prisma/migrations/20250720211458_apiid_int/migration.sql
+++ b/backend/prisma/migrations/20250720211458_apiid_int/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `apiId` column on the `Recipe` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Recipe" DROP COLUMN "apiId",
+ADD COLUMN     "apiId" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Recipe_apiId_editingAuthorId_key" ON "Recipe"("apiId", "editingAuthorId");

--- a/backend/prisma/migrations/20250720212318_apiid/migration.sql
+++ b/backend/prisma/migrations/20250720212318_apiid/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recipe" ALTER COLUMN "apiId" DROP DEFAULT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,7 +52,7 @@ model Ingredient {
 // https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations
 model Recipe {
   id                 Int      @id @default(autoincrement()) // store the id number from spoonacular api, otherwise id is auto incremented (part of the users database)
-  apiId              Int      
+  apiId              Int
   originalSource     String
   editingAuthorName  String
   recipeTitle        String
@@ -71,5 +71,6 @@ model Recipe {
   usersThatFavorited User[]   @relation("FavoritedRecipes")
   editingAuthorId    Int?
   editingAuthor      User?    @relation(fields: [editingAuthorId], references: [id])
-  @@unique ([apiId, editingAuthorId])
+
+  @@unique([apiId, editingAuthorId])
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   groceryListCost  Decimal           @default(0.00)
   recipes          Recipe[]          @relation("PlannedRecipes")
   favoritedRecipes Recipe[]          @relation("FavoritedRecipes")
+  editedRecipes    Recipe[]
 }
 
 model OwnedIngredient {
@@ -51,9 +52,9 @@ model Ingredient {
 // https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations
 model Recipe {
   id                 Int      @id @default(autoincrement()) // store the id number from spoonacular api, otherwise id is auto incremented (part of the users database)
-  apiId              Int      @unique
+  apiId              Int      
   originalSource     String
-  editingAuthor      String
+  editingAuthorName  String
   recipeTitle        String
   previewImage       String // if image not provided, generic image will be presented
   servings           Int
@@ -68,4 +69,7 @@ model Recipe {
   dairyFree          Boolean
   users              User[]   @relation("PlannedRecipes")
   usersThatFavorited User[]   @relation("FavoritedRecipes")
+  editingAuthorId    Int?
+  editingAuthor      User?    @relation(fields: [editingAuthorId], references: [id])
+  @@unique ([apiId, editingAuthorId])
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -72,5 +72,6 @@ model Recipe {
   editingAuthorId    Int?
   editingAuthor      User?    @relation(fields: [editingAuthorId], references: [id])
 
+
   @@unique([apiId, editingAuthorId])
 }

--- a/backend/routes/recipeRoutes.ts
+++ b/backend/routes/recipeRoutes.ts
@@ -111,9 +111,10 @@ router.post(
   async (req: Request, res: Response) => {
     const userId = parseInt(req.params.userId);
     const {
+      editedRecipe,
       apiId,
-      originalAuthor,
-      editingAuthor,
+      originalSource,
+      editingAuthorName,
       recipeTitle,
       previewImage,
       servings,
@@ -138,20 +139,26 @@ router.post(
       return res.status(400).send("Missing required recipe fields");
     }
     try {
-      // check if recipe already in database
-      let recipe = await prisma.Recipe.findUnique({
-        where: {
-          apiId: apiId,
-        },
-      });
+      // check if recipe already in database and not edited
+      let recipe = null;
+      if (!editedRecipe) {
+        // if recipe is edited, there will be 2 recipes with identical api ids
+        // not an edited recipe, look for api id
+        recipe = await prisma.Recipe.findFirst({
+          where: {
+            apiId: apiId,
+            editingAuthorId: null,
+          },
+        });
+      }
 
       if (!recipe) {
-        // no recipe found, make new recipe
-        recipe = await prisma.Recipe.create({
+        // no recipe found or editing, make new recipe
+        recipe = await prisma.recipe.create({
           data: {
             apiId,
-            originalAuthor,
-            editingAuthor,
+            originalSource,
+            editingAuthorName,
             recipeTitle,
             previewImage,
             servings,
@@ -170,16 +177,21 @@ router.post(
       if (!recipe) {
         return res.status(400).send("Error, failed to create recipe");
       }
+      const connector = editedRecipe
+        ? { editingAuthor: { connect: { id: userId } } }
+        : {
+            users: {
+              connect: {
+                id: userId,
+              },
+            },
+          };
       recipe = await prisma.recipe.update({
         where: {
-          apiId: apiId,
+          id: recipe.id
         },
         data: {
-          users: {
-            connect: {
-              id: userId,
-            },
-          },
+          ...connector,
         },
       });
       res.json(recipe);
@@ -200,14 +212,7 @@ router.post(
       return res.status(400).send("Missing recipe id");
     }
     try {
-      // check if recipe already in database
-      let recipe = await prisma.Recipe.findUnique({
-        where: {
-          apiId: apiId,
-        },
-      });
-
-      recipe = await prisma.recipe.update({
+      const recipe = await prisma.recipe.update({
         where: {
           apiId: apiId,
         },

--- a/frontend/src/components/EditRecipeModal.tsx
+++ b/frontend/src/components/EditRecipeModal.tsx
@@ -72,9 +72,11 @@ const EditRecipeModal = ({
   toggleModal,
 }: GPEditRecipeModalType) => {
   const initialRecipeState = recipe ?? {
+    id: 0,
     apiId: 0,
     originalSource: "",
     editingAuthorName: "",
+    editingAuthorId: null,
     recipeTitle: "",
     previewImage:
       "https://images.pexels.com/photos/1435904/pexels-photo-1435904.jpeg",
@@ -228,8 +230,8 @@ const EditRecipeModal = ({
                       <Typography level="h4">Edit Recipe</Typography>
                     </Grid>
                     {recipeInputEditFields.map((field, index) => (
-                      <Grid xs={field.spacing}>
-                        <FormControl key={index}>
+                      <Grid  key={index} xs={field.spacing}>
+                        <FormControl>
                           <FormLabel>{field.label}</FormLabel>
                           <Input
                             required

--- a/frontend/src/components/MealCard.tsx
+++ b/frontend/src/components/MealCard.tsx
@@ -15,6 +15,7 @@ import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
+import PersonIcon from "@mui/icons-material/Person";
 import RecipeCostModal from "./RecipeCostModal";
 import DietsAndIntolerances from "./DietsAndIntolerances";
 import { estimateRecipeCost } from "../utils/utils";
@@ -156,13 +157,12 @@ const MealCard: React.FC<GPMealCardProps> = ({
           <img src={parsedMealData.previewImage} />
         </AspectRatio>
         <CardContent sx={{ justifyContent: "flex-end" }}>
-          <Box
-            sx={{
-              color: "primary",
-              display: "flex",
-              justifyContent: "space-between",
-            }}
-          ></Box>
+          {parsedMealData.editingAuthorName && (
+            <Box sx={{display: "flex", alignItems: "center", gap: 1}}>
+              <PersonIcon />
+              <Typography>Edited by: {parsedMealData.editingAuthorName}</Typography>
+            </Box>
+          )}
           {onSelectRecipe && (
             <DietsAndIntolerances recipeInfo={parsedMealData} />
           )}
@@ -180,9 +180,7 @@ const MealCard: React.FC<GPMealCardProps> = ({
               <DeleteIcon />
             </IconButton>
           )}
-          <Box
-            sx={{display: "flex", justifyContent: "space-between"}}
-          >
+          <Box sx={{ display: "flex", justifyContent: "space-between" }}>
             {onSelectRecipe && (
               <Tooltip title="Add to recipes to shop">
                 <Button
@@ -201,10 +199,12 @@ const MealCard: React.FC<GPMealCardProps> = ({
             )}
             {onEditRecipe && (
               <Tooltip title="Add your own edits!">
-                <IconButton onClick={(event) => {
-                  event.stopPropagation()
-                  onEditRecipe(parsedMealData)
-                }}>
+                <IconButton
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onEditRecipe(parsedMealData);
+                  }}
+                >
                   <EditIcon />
                 </IconButton>
               </Tooltip>

--- a/frontend/src/components/MealInfoModal.tsx
+++ b/frontend/src/components/MealInfoModal.tsx
@@ -3,6 +3,7 @@ import { GPModalStyle } from "../utils/UIStyle";
 import type { GPRecipeDataTypes } from "../utils/types";
 import {
   Modal,
+  Button,
   Typography,
   Sheet,
   List,
@@ -12,7 +13,8 @@ import {
   Link,
   AspectRatio,
 } from "@mui/joy";
-import LinkIcon from '@mui/icons-material/Link';
+import PersonIcon from "@mui/icons-material/Person";
+import LinkIcon from "@mui/icons-material/Link";
 import DietsAndIntolerances from "./DietsAndIntolerances";
 import { GPCenteredBoxStyle } from "../utils/UIStyle";
 
@@ -35,17 +37,26 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
       sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
     >
       <Sheet variant="outlined" sx={GPModalStyle}>
-        <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-          <AspectRatio ratio="1" sx={{ width: "50%", borderRadius: "md"}}>
+        <Box sx={{ display: "flex", justifyContent: "space-around" }}>
+          <AspectRatio ratio="1" sx={{ width: "50%", borderRadius: "md" }}>
             <img src={recipeInfo?.previewImage} />
           </AspectRatio>
-          <Box
-            sx={GPCenteredBoxStyle}
-          >
+          <Box sx={GPCenteredBoxStyle}>
             <Typography level="h2">{recipeInfo?.recipeTitle}</Typography>
+            {recipeInfo?.editingAuthorName && (
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+                <PersonIcon />
+                <Typography>
+                  Edited by: {recipeInfo.editingAuthorName}
+                </Typography>
+                <Button>Compare With Original Recipe</Button>
+              </Box>
+            )}
             <Typography>Servings: {recipeInfo?.servings}</Typography>
             <DietsAndIntolerances recipeInfo={recipeInfo} />
-            <Link href={recipeInfo?.sourceUrl} startDecorator={<LinkIcon/>}>Recipe link</Link>
+            <Link href={recipeInfo?.sourceUrl} startDecorator={<LinkIcon />}>
+              Recipe link
+            </Link>
           </Box>
         </Box>
         <Box>
@@ -53,9 +64,7 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
           <List marker="circle">
             {(recipeInfo?.ingredients ?? []).map((ingredient, index) => {
               return (
-                <ListItem
-                  key={index}
-                >
+                <ListItem key={index}>
                   <ListItemContent
                     sx={{ display: "flex", justifyContent: "space-between" }}
                   >

--- a/frontend/src/pages/FavoritedRecipes.tsx
+++ b/frontend/src/pages/FavoritedRecipes.tsx
@@ -51,7 +51,7 @@ const FavoritedRecipes = () => {
     }
     try {
       const userId = user.id;
-      await updateUserRecipes({ userId, selectedRecipe: recipe, setMessage });
+      await updateUserRecipes({ userId, editedRecipe: false, selectedRecipe: recipe, setMessage });
     } catch (error) {
       setMessage({ error: true, message: "Error adding recipe" });
     }

--- a/frontend/src/pages/FavoritedRecipes.tsx
+++ b/frontend/src/pages/FavoritedRecipes.tsx
@@ -35,7 +35,7 @@ const FavoritedRecipes = () => {
   const onFavoriteClick = (recipe: GPRecipeDataTypes) => {
     handleUnfavoriteRecipe({ setMessage, recipe });
     setFavoritedRecipes((prev) =>
-      prev.filter((elem) => elem.apiId !== recipe.apiId)
+      prev.filter((elem) => elem.id !== recipe.id)
     );
   };
 

--- a/frontend/src/pages/NewListPage.tsx
+++ b/frontend/src/pages/NewListPage.tsx
@@ -67,8 +67,8 @@ const NewListPage = () => {
   const handleDeleteRecipe = async (deletedRecipe: GPRecipeDataTypes) => {
     try {
       await axios.put(
-        `${databaseUrl}/recipes/planned/${deletedRecipe.apiId}`,
-        {},
+        `${databaseUrl}/recipes/planned/remove`,
+        {deletedRecipe},
         axiosConfig
       );
       await fetchRecipes({ setMessage, setRecipes: setSelectedRecipes, recipeGroup: "planned" });

--- a/frontend/src/pages/NewListPage.tsx
+++ b/frontend/src/pages/NewListPage.tsx
@@ -48,7 +48,7 @@ const NewListPage = () => {
     }
     try {
       const userId = user.id;
-      await updateUserRecipes({ userId, selectedRecipe, setMessage });
+      await updateUserRecipes({ editedRecipe: false, userId, selectedRecipe, setMessage });
       await fetchRecipes({ setMessage, setRecipes: setSelectedRecipes, recipeGroup: "planned" });
     } catch (error) {
       setMessage({ error: true, message: "Error adding recipe" });

--- a/frontend/src/pages/RecipeDiscoveryPage.tsx
+++ b/frontend/src/pages/RecipeDiscoveryPage.tsx
@@ -87,7 +87,7 @@ const RecipeDiscoveryPage = () => {
     }
     try {
       const userId = user.id;
-      await updateUserRecipes({ userId, selectedRecipe: recipe, setMessage });
+      await updateUserRecipes({ userId, editedRecipe: false, selectedRecipe: recipe, setMessage });
     } catch (error) {
       setMessage({ error: true, message: "Error adding recipe" });
     }

--- a/frontend/src/pages/RecipeDiscoveryPage.tsx
+++ b/frontend/src/pages/RecipeDiscoveryPage.tsx
@@ -69,7 +69,7 @@ const RecipeDiscoveryPage = () => {
       });
       // set favorited recipes id
       for (const elem of favoritedRecipesReturn) {
-        setFavoritedRecipesId(prev => new Set(prev.add(elem.apiId)));
+        setFavoritedRecipesId(prev => new Set(prev.add(elem.id)));
       }
     }
     setRecipeLists();
@@ -95,11 +95,11 @@ const RecipeDiscoveryPage = () => {
 
   const handleFavoriteClick = async (recipe: GPRecipeDataTypes) => {
     if (user) {
-      if (favoritedRecipesId.has(recipe.apiId)) {
+      if (favoritedRecipesId.has(recipe.id)) {
         handleUnfavoriteRecipe({ setMessage, recipe });
         // Removing an element from set useState variable
         setFavoritedRecipesId((prev) => {
-          prev.delete(recipe.apiId);
+          prev.delete(recipe.id);
           return new Set(prev);
         });
       } else {
@@ -108,7 +108,7 @@ const RecipeDiscoveryPage = () => {
           userId: user.id,
           selectedRecipe: recipe,
         });
-        setFavoritedRecipesId(prev => new Set(prev.add(recipe.apiId)))
+        setFavoritedRecipesId(prev => new Set(prev.add(recipe.id)))
       }
       fetchAllRecipeCategories({
         setMessage,
@@ -157,7 +157,7 @@ const RecipeDiscoveryPage = () => {
                 setMessage={setMessage}
                 selectedToCompare={false}
                 {...(user && { onFavoriteClick: handleFavoriteClick })}
-                favorited={favoritedRecipesId.has(meal.apiId)}
+                favorited={favoritedRecipesId.has(meal.id)}
                 cardSize={300}
               />
             )}

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -26,6 +26,7 @@ const IngredientDataFields = {
 };
 
 const RecipeDataFields = {
+  ID: "id",
   API_ID: "apiId",
   TITLE: "recipeTitle",
   IMAGE: "previewImage",

--- a/frontend/src/utils/databaseHelpers.ts
+++ b/frontend/src/utils/databaseHelpers.ts
@@ -194,10 +194,12 @@ const fetchRecipes = async ({
 };
 
 type GPUpdateUserRecipesTypes = GPSetMessageType & {
+  editedRecipe: boolean;
   selectedRecipe: GPRecipeDataTypes;
   userId: string;
 };
 const updateUserRecipes = async ({
+  editedRecipe,
   userId,
   selectedRecipe,
   setMessage,
@@ -205,7 +207,7 @@ const updateUserRecipes = async ({
   try {
     await axios.post(
       `${databaseUrl}/recipes/planned/${userId}`,
-      selectedRecipe,
+      { editedRecipe: editedRecipe, ...selectedRecipe },
       axiosConfig
     );
   } catch (error) {
@@ -336,11 +338,16 @@ const handleUnfavoriteRecipe = async ({
   }
 };
 
+type GPFavoriteType = GPSetMessageType & {
+  userId: string;
+  selectedRecipe: GPRecipeDataTypes;
+};
+
 const handleFavoriteRecipe = async ({
   setMessage,
   userId,
   selectedRecipe,
-}: GPUpdateUserRecipesTypes) => {
+}: GPFavoriteType) => {
   try {
     await axios.post(
       `${databaseUrl}/recipes/favorited/${userId}`,

--- a/frontend/src/utils/databaseHelpers.ts
+++ b/frontend/src/utils/databaseHelpers.ts
@@ -329,8 +329,8 @@ const handleUnfavoriteRecipe = async ({
 }: GPUnfavoriteType) => {
   try {
     await axios.put(
-      `${databaseUrl}/recipes/favorited/${recipe.apiId}`,
-      {},
+      `${databaseUrl}/recipes/favorited/unfavorite`,
+      { selectedRecipe: recipe },
       axiosConfig
     );
   } catch (error) {
@@ -351,7 +351,7 @@ const handleFavoriteRecipe = async ({
   try {
     await axios.post(
       `${databaseUrl}/recipes/favorited/${userId}`,
-      { apiId: selectedRecipe.apiId },
+      { selectedRecipe },
       axiosConfig
     );
   } catch (error) {

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -2,9 +2,11 @@ import type { User } from "firebase/auth";
 import TimeBlock from "../../../backend/utils/TimeBlockClass";
 
 type GPRecipeDataTypes = {
+  id: number,
   apiId: number;
   originalSource: string;
   editingAuthorName: string;
+  editingAuthorId: number | null;
   recipeTitle: string;
   previewImage: string;
   servings: number;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -4,7 +4,7 @@ import TimeBlock from "../../../backend/utils/TimeBlockClass";
 type GPRecipeDataTypes = {
   apiId: number;
   originalSource: string;
-  editingAuthor: string;
+  editingAuthorName: string;
   recipeTitle: string;
   previewImage: string;
   servings: number;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -19,7 +19,8 @@ const parseRecipeData = async (recipeData: any) => {
       );
       return {
         apiId: recipe.id,
-        originalAuthor: recipe.sourceName,
+        originalSource: recipe.sourceName,
+        editingAuthorName: "",
         recipeTitle: recipe.title,
         previewImage: recipe.image,
         servings: recipe.servings,

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -21,6 +21,7 @@ const parseRecipeData = async (recipeData: any) => {
         apiId: recipe.id,
         originalSource: recipe.sourceName,
         editingAuthorName: "",
+        editingAuthorId: null,
         recipeTitle: recipe.title,
         previewImage: recipe.image,
         servings: recipe.servings,


### PR DESCRIPTION
## Description

<what this pull request is doing>

- add a users edited recipe to the database to be presented with other recipes on the discovery page
- adjust the recipe type structure to hold the recipe id from prisma
- replace instances of apiId as a unique identify with the recipes id as the unique identifier

<what will be done in later PRs and not included here>

- link edited recipe back to the original recipe

## Milestones
<the milestones or stories/features that this works towards>

- TC2 saving edited recipes backend functionality

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>

## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>

- removed unique identifier on api id to allow multiple recipes to be stored from the same api id
- display edited recipe on other user accounts