### PR TITLE
Allow support for multiple images when editing a recipe

### DIFF
--- a/backend/prisma/migrations/20250724073517_recipe_images/migration.sql
+++ b/backend/prisma/migrations/20250724073517_recipe_images/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `previewImage` column on the `Recipe` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Recipe" DROP COLUMN "previewImage",
+ADD COLUMN     "previewImage" TEXT[] DEFAULT ARRAY['']::TEXT[];

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,7 +49,7 @@ model Recipe {
   originalSource     String
   editingAuthorName  String
   recipeTitle        String
-  previewImage       String
+  previewImage       String[]        @default([""])
   servings           Int
   ingredients        Json
   sourceUrl          String

--- a/backend/utils/calendarUtils.ts
+++ b/backend/utils/calendarUtils.ts
@@ -111,7 +111,7 @@ const getMealPrepTimeOptions = ({
         0,
         "",
         "Prep Block",
-        "https://images.pexels.com/photos/1435910/pexels-photo-1435910.jpeg",
+        ["https://images.pexels.com/photos/1435910/pexels-photo-1435910.jpeg"],
         sumAllServings,
         [],
         [],
@@ -122,7 +122,7 @@ const getMealPrepTimeOptions = ({
         false,
         false,
         [],
-        null,
+        null
       ),
     };
     eventOptions = [...eventOptions, bestBlock];
@@ -204,7 +204,7 @@ const getAnyFreeTime = ({
   const freeBlockEnd = endAsDate.getTime();
   let optionArray: TimeBlock[] = [];
   const preferredStarts = new Set(
-    preferredOptions.map((option) => option.start.getTime()),
+    preferredOptions.map((option) => option.start.getTime())
   );
 
   while (freeBlockStart + readyInMilliseconds <= freeBlockEnd) {
@@ -213,7 +213,7 @@ const getAnyFreeTime = ({
         ...optionArray,
         new TimeBlock(
           new Date(freeBlockStart),
-          new Date(freeBlockStart + readyInMilliseconds),
+          new Date(freeBlockStart + readyInMilliseconds)
         ),
       ];
     }
@@ -258,7 +258,7 @@ const fitsUserPreferences = ({
 
     const userPreferenceTimeBlock = new TimeBlock(
       new Date(preferredStart),
-      new Date(preferredEnd),
+      new Date(preferredEnd)
     );
     const overlap = userPreferenceTimeBlock.getOverlap(freeTimeBlock);
 
@@ -266,7 +266,7 @@ const fitsUserPreferences = ({
       let optionArray = [
         new TimeBlock(
           new Date(overlap.start),
-          new Date(overlap.start + readyInMilliseconds),
+          new Date(overlap.start + readyInMilliseconds)
         ),
       ];
       const newStart = overlap.start + TO_MILLISECONDS * TIME_BLOCK_INCREMENT;
@@ -275,7 +275,7 @@ const fitsUserPreferences = ({
           ...optionArray,
           new TimeBlock(
             new Date(newStart),
-            new Date(newStart + readyInMilliseconds),
+            new Date(newStart + readyInMilliseconds)
           ),
         ];
       }

--- a/frontend/src/components/calendar/CalendarEventCard.tsx
+++ b/frontend/src/components/calendar/CalendarEventCard.tsx
@@ -84,8 +84,8 @@ const CalendarEventCard = ({ eventOption, groupNum }: GPCalendarOption) => {
       </Box>
       <AspectRatio minHeight="120px" maxHeight="200px">
         <img
-          src={recipe.previewImage}
-          srcSet={recipe.previewImage}
+          src={recipe.previewImage[0]}
+          srcSet={recipe.previewImage[0]}
           loading="lazy"
           alt=""
         />

--- a/frontend/src/components/recipeDiff/DiffOriginalRecipe.tsx
+++ b/frontend/src/components/recipeDiff/DiffOriginalRecipe.tsx
@@ -90,7 +90,7 @@ const DiffOriginalRecipe = ({
           <DialogContent sx={{ m: 4 }}>
             <Box sx={GPMealInfoModalTitleStyle}>
               <AspectRatio ratio="1" sx={{ width: 350, borderRadius: "md" }}>
-                <img src={originalRecipeInfo.previewImage} />
+                <img src={originalRecipeInfo.previewImage[0]} />
               </AspectRatio>
               <Box sx={GPCenteredBoxStyle}>
                 {recipeDiffInfo?.titleDiffResults && (

--- a/frontend/src/components/recipeDiff/EditRecipeModal.tsx
+++ b/frontend/src/components/recipeDiff/EditRecipeModal.tsx
@@ -31,6 +31,7 @@ import { useUser } from "../../contexts/UserContext";
 import { updateUserRecipes } from "../../utils/databaseHelpers";
 import { Recipe } from "../../../../shared/Recipe";
 import InfoOutlined from "@mui/icons-material/InfoOutline";
+import ImageSearchModal from "./ImageSearchModal";
 
 type GPEditRecipeModalType = {
   recipe: Recipe | undefined;
@@ -42,6 +43,7 @@ type GPEditRecipeModalType = {
 const actions = {
   SET_RECIPE: "setRecipe",
   SET_INPUT: "setInput",
+  SET_IMAGE: "setImage",
   SET_INPUT_NUM: "setInputNum",
   SET_DIETARY_TAGS: "toggleTag",
   UPDATE_INGREDIENT: "setIngredient",
@@ -95,8 +97,9 @@ const EditRecipeModal = ({
     editingAuthorName: "",
     editingAuthorId: null,
     recipeTitle: "",
-    previewImage:
+    previewImage: [
       "https://images.pexels.com/photos/1435904/pexels-photo-1435904.jpeg",
+    ],
     servings: 0,
     ingredients: [],
     instructions: [],
@@ -119,6 +122,10 @@ const EditRecipeModal = ({
     | {
         type: typeof actions.SET_INPUT;
         recipeField: keyof GPRecipeDataTypes;
+        value: string;
+      }
+    | {
+        type: typeof actions.SET_IMAGE;
         value: string;
       }
     | {
@@ -156,6 +163,7 @@ const EditRecipeModal = ({
   const [inputError, setInputError] = useState(false);
   const [editedRecipeData, dispatch] = useReducer(reducer, initialRecipeState);
   const [message, setMessage] = useState<GPErrorMessageTypes>();
+  const [imageSearchModalOpen, setImageSearchModalOpen] = useState(false);
   const { user } = useUser();
 
   function reducer(state: GPRecipeDataTypes, action: ACTIONTYPE) {
@@ -276,227 +284,244 @@ const EditRecipeModal = ({
     }
   };
 
+  const handleNewImages = (selectedImages: Set<string>) => {
+  };
+
   return (
-    <Modal open={modalOpen} onClose={toggleModal}>
-      <ModalDialog layout="fullscreen">
-        <ModalClose sx={{ zIndex: 2 }} />
-        <DialogContent>
-          <form onSubmit={handleRecipeSubmit}>
-            <Box>
-              <Box sx={{ m: 1 }}>
-                <Grid container spacing={2} sx={{ alignItems: "flex-end" }}>
-                  <Grid container xs={9}>
-                    <Grid
-                      sx={{
-                        flexGrow: 1,
-                        p: 2,
-                        bgcolor: "primary.300",
-                        borderRadius: "md",
-                      }}
-                    >
-                      <Typography level="h4">Edit Recipe</Typography>
-                    </Grid>
-                    {recipeInputEditFields.map((field, index) => (
-                      <Grid key={index} xs={field.spacing}>
-                        <FormControl>
-                          <FormLabel>{field.label}</FormLabel>
-                          <Input
-                            required
-                            type={
-                              field.field === EditRecipeFieldsEnum.SERVINGS ||
-                              field.field === EditRecipeFieldsEnum.READY_IN
-                                ? "number"
-                                : "text"
-                            }
-                            onChange={(event) => {
-                              field.field === EditRecipeFieldsEnum.SERVINGS ||
-                              field.field === EditRecipeFieldsEnum.READY_IN
-                                ? dispatch({
-                                    type: actions.SET_INPUT_NUM,
-                                    recipeField: field.field,
-                                    value: parseInt(event.target.value),
-                                  })
-                                : dispatch({
-                                    type: actions.SET_INPUT,
-                                    recipeField: field.field,
-                                    value: event.target.value,
-                                  });
-                            }}
-                            value={editedRecipeData[field.field] ?? ""}
-                          />
-                        </FormControl>
+    <>
+      <Modal open={modalOpen} onClose={toggleModal}>
+        <ModalDialog layout="fullscreen">
+          <ModalClose sx={{ zIndex: 2 }} />
+          <DialogContent>
+            <form onSubmit={handleRecipeSubmit}>
+              <Box>
+                <Box sx={{ m: 1 }}>
+                  <Grid container spacing={2} sx={{ alignItems: "flex-end" }}>
+                    <Grid container xs={9}>
+                      <Grid
+                        sx={{
+                          flexGrow: 1,
+                          p: 2,
+                          bgcolor: "primary.300",
+                          borderRadius: "md",
+                        }}
+                      >
+                        <Typography level="h4">Edit Recipe</Typography>
                       </Grid>
-                    ))}
+                      {recipeInputEditFields.map((field, index) => (
+                        <Grid key={index} xs={field.spacing}>
+                          <FormControl>
+                            <FormLabel>{field.label}</FormLabel>
+                            <Input
+                              required
+                              type={
+                                field.field === EditRecipeFieldsEnum.SERVINGS ||
+                                field.field === EditRecipeFieldsEnum.READY_IN
+                                  ? "number"
+                                  : "text"
+                              }
+                              onChange={(event) => {
+                                field.field === EditRecipeFieldsEnum.SERVINGS ||
+                                field.field === EditRecipeFieldsEnum.READY_IN
+                                  ? dispatch({
+                                      type: actions.SET_INPUT_NUM,
+                                      recipeField: field.field,
+                                      value: parseInt(event.target.value),
+                                    })
+                                  : dispatch({
+                                      type: actions.SET_INPUT,
+                                      recipeField: field.field,
+                                      value: event.target.value,
+                                    });
+                              }}
+                              value={editedRecipeData[field.field] ?? ""}
+                            />
+                          </FormControl>
+                        </Grid>
+                      ))}
+                    </Grid>
+                    <Grid xs={3}>
+                      <TitledListView
+                        itemsList={dietaryEditFields}
+                        headerList={[
+                          {
+                            title: "Recipe Tags",
+                            spacing: MUI_GRID_FULL_SPACE,
+                          },
+                        ]}
+                        renderItem={(tag, index) => (
+                          <Button
+                            key={index}
+                            sx={{ p: 1 }}
+                            value={tag.field}
+                            variant={
+                              editedRecipeData[
+                                tag.field as keyof GPRecipeDataTypes
+                              ]
+                                ? "solid"
+                                : "plain"
+                            }
+                            onClick={() =>
+                              dispatch({
+                                type: actions.SET_DIETARY_TAGS,
+                                dietTag: tag.field as keyof GPRecipeDataTypes,
+                                dietLabel: tag.label,
+                              })
+                            }
+                          >
+                            {tag.label}
+                          </Button>
+                        )}
+                        listItemsStyle={RecipeTagsTitledListStyle}
+                      />
+                    </Grid>
                   </Grid>
-                  <Grid xs={3}>
-                    <TitledListView
-                      itemsList={dietaryEditFields}
-                      headerList={[
-                        { title: "Recipe Tags", spacing: MUI_GRID_FULL_SPACE },
-                      ]}
-                      renderItem={(tag, index) => (
-                        <Button
-                          key={index}
-                          sx={{ p: 1 }}
-                          value={tag.field}
-                          variant={
-                            editedRecipeData[
-                              tag.field as keyof GPRecipeDataTypes
-                            ]
-                              ? "solid"
-                              : "plain"
-                          }
+                </Box>
+                <Button onClick={() => setImageSearchModalOpen(true)}>
+                  Add Images!
+                </Button>
+                <TitledListView
+                  itemsList={editedRecipeData.ingredients}
+                  headerList={[
+                    { title: "Ingredients", spacing: MUI_GRID_FULL_SPACE },
+                  ]}
+                  renderItem={(ingredient, ingredientIndex) => (
+                    <Grid container key={ingredientIndex} alignItems="center">
+                      {ingredientInputEditFields.map((field, fieldIndex) => (
+                        <Grid key={fieldIndex} xs={field.space}>
+                          <FormControl>
+                            <FormHelperText>{field.label}</FormHelperText>
+                            <Input
+                              type={
+                                field.field ===
+                                EditRecipeFieldsEnum.ING_QUANTITY
+                                  ? "number"
+                                  : "text"
+                              }
+                              onChange={(event) =>
+                                dispatch({
+                                  type: actions.UPDATE_INGREDIENT,
+                                  ingredientIndex: ingredientIndex,
+                                  ingredientField:
+                                    field.field as keyof GPIngredientDataTypes,
+                                  value: event.target.value,
+                                })
+                              }
+                              value={ingredient[field.field]}
+                            />
+                          </FormControl>
+                        </Grid>
+                      ))}
+                      <Grid xs={1}>
+                        <IconButton
                           onClick={() =>
                             dispatch({
-                              type: actions.SET_DIETARY_TAGS,
-                              dietTag: tag.field as keyof GPRecipeDataTypes,
-                              dietLabel: tag.label,
+                              type: actions.DELETE_ITEM,
+                              deletedField: "ingredients",
+                              itemIndex: ingredientIndex,
                             })
                           }
                         >
-                          {tag.label}
-                        </Button>
-                      )}
-                      listItemsStyle={RecipeTagsTitledListStyle}
-                    />
-                  </Grid>
-                </Grid>
-              </Box>
-              <TitledListView
-                itemsList={editedRecipeData.ingredients}
-                headerList={[
-                  { title: "Ingredients", spacing: MUI_GRID_FULL_SPACE },
-                ]}
-                renderItem={(ingredient, ingredientIndex) => (
-                  <Grid container key={ingredientIndex} alignItems="center">
-                    {ingredientInputEditFields.map((field, fieldIndex) => (
-                      <Grid key={fieldIndex} xs={field.space}>
+                          <RemoveCircleOutlineIcon />
+                        </IconButton>
+                      </Grid>
+                    </Grid>
+                  )}
+                />
+                <IconButton
+                  sx={{ justifySelf: "flex-end" }}
+                  onClick={() =>
+                    dispatch({
+                      type: actions.ADD_ITEM,
+                      addedField: "ingredients",
+                      addedItem: {
+                        id: 0,
+                        ingredientName: "",
+                        quantity: 0,
+                        unit: "",
+                        department: "",
+                        isChecked: false,
+                      },
+                    })
+                  }
+                >
+                  <AddCircleOutlineIcon />
+                </IconButton>
+                <TitledListView
+                  headerList={[
+                    { title: "Instructions", spacing: MUI_GRID_FULL_SPACE },
+                  ]}
+                  itemsList={editedRecipeData.instructions}
+                  renderItem={(step, index) => (
+                    <Grid container key={index} sx={{ alignItems: "center" }}>
+                      <Grid xs={1}>
+                        <Typography>#{index + 1}</Typography>
+                      </Grid>
+                      <Grid xs={10}>
                         <FormControl>
-                          <FormHelperText>{field.label}</FormHelperText>
-                          <Input
-                            type={
-                              field.field === EditRecipeFieldsEnum.ING_QUANTITY
-                                ? "number"
-                                : "text"
-                            }
+                          <Textarea
+                            required
                             onChange={(event) =>
                               dispatch({
-                                type: actions.UPDATE_INGREDIENT,
-                                ingredientIndex: ingredientIndex,
-                                ingredientField:
-                                  field.field as keyof GPIngredientDataTypes,
+                                type: actions.UPDATE_INSTRUCTION,
+                                instructionIndex: index,
                                 value: event.target.value,
                               })
                             }
-                            value={ingredient[field.field]}
+                            value={step}
                           />
                         </FormControl>
                       </Grid>
-                    ))}
-                    <Grid xs={1}>
-                      <IconButton
-                        onClick={() =>
-                          dispatch({
-                            type: actions.DELETE_ITEM,
-                            deletedField: "ingredients",
-                            itemIndex: ingredientIndex,
-                          })
-                        }
-                      >
-                        <RemoveCircleOutlineIcon />
-                      </IconButton>
-                    </Grid>
-                  </Grid>
-                )}
-              />
-              <IconButton
-                sx={{ justifySelf: "flex-end" }}
-                onClick={() =>
-                  dispatch({
-                    type: actions.ADD_ITEM,
-                    addedField: "ingredients",
-                    addedItem: {
-                      id: 0,
-                      ingredientName: "",
-                      quantity: 0,
-                      unit: "",
-                      department: "",
-                      isChecked: false,
-                    },
-                  })
-                }
-              >
-                <AddCircleOutlineIcon />
-              </IconButton>
-              <TitledListView
-                headerList={[
-                  { title: "Instructions", spacing: MUI_GRID_FULL_SPACE },
-                ]}
-                itemsList={editedRecipeData.instructions}
-                renderItem={(step, index) => (
-                  <Grid container key={index} sx={{ alignItems: "center" }}>
-                    <Grid xs={1}>
-                      <Typography>#{index + 1}</Typography>
-                    </Grid>
-                    <Grid xs={10}>
-                      <FormControl>
-                        <Textarea
-                          required
-                          onChange={(event) =>
+                      <Grid xs={1}>
+                        <IconButton
+                          onClick={() =>
                             dispatch({
-                              type: actions.UPDATE_INSTRUCTION,
-                              instructionIndex: index,
-                              value: event.target.value,
+                              type: actions.DELETE_ITEM,
+                              deletedField: "instructions",
+                              itemIndex: index,
                             })
                           }
-                          value={step}
-                        />
-                      </FormControl>
+                        >
+                          <RemoveCircleOutlineIcon />
+                        </IconButton>
+                      </Grid>
                     </Grid>
-                    <Grid xs={1}>
-                      <IconButton
-                        onClick={() =>
-                          dispatch({
-                            type: actions.DELETE_ITEM,
-                            deletedField: "instructions",
-                            itemIndex: index,
-                          })
-                        }
-                      >
-                        <RemoveCircleOutlineIcon />
-                      </IconButton>
-                    </Grid>
-                  </Grid>
+                  )}
+                />
+                <IconButton
+                  sx={{ justifySelf: "flex-end" }}
+                  onClick={(event) =>
+                    dispatch({
+                      type: actions.ADD_ITEM,
+                      addedField: "instructions",
+                      addedItem: "",
+                    })
+                  }
+                >
+                  <AddCircleOutlineIcon />
+                </IconButton>
+              </Box>
+              <FormControl error={inputError}>
+                <Button type="submit" disabled={inputError}>
+                  Update Recipe!
+                </Button>
+                {inputError && (
+                  <FormHelperText>
+                    <InfoOutlined />
+                    Must enter valid input to submit
+                  </FormHelperText>
                 )}
-              />
-              <IconButton
-                sx={{ justifySelf: "flex-end" }}
-                onClick={(event) =>
-                  dispatch({
-                    type: actions.ADD_ITEM,
-                    addedField: "instructions",
-                    addedItem: "",
-                  })
-                }
-              >
-                <AddCircleOutlineIcon />
-              </IconButton>
-            </Box>
-            <FormControl error={inputError}>
-              <Button type="submit" disabled={inputError}>
-                Update Recipe!
-              </Button>
-              {inputError && (
-                <FormHelperText>
-                  <InfoOutlined />
-                  Must enter valid input to submit
-                </FormHelperText>
-              )}
-            </FormControl>
-          </form>
-        </DialogContent>
-      </ModalDialog>
-    </Modal>
+              </FormControl>
+            </form>
+          </DialogContent>
+        </ModalDialog>
+      </Modal>
+      <ImageSearchModal
+        modalOpen={imageSearchModalOpen}
+        toggleModal={() => setImageSearchModalOpen((prev) => !prev)}
+        onSubmit={handleNewImages}
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/recipeDiff/EditRecipeModal.tsx
+++ b/frontend/src/components/recipeDiff/EditRecipeModal.tsx
@@ -19,6 +19,7 @@ import {
   Typography,
   IconButton,
   Textarea,
+  AspectRatio,
 } from "@mui/joy";
 import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutline";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
@@ -126,7 +127,7 @@ const EditRecipeModal = ({
       }
     | {
         type: typeof actions.SET_IMAGE;
-        value: string;
+        value: Set<string>;
       }
     | {
         type: typeof actions.SET_INPUT_NUM;
@@ -189,6 +190,11 @@ const EditRecipeModal = ({
           ...state,
           [action.dietTag]: !state[action.dietTag],
           recipeTags: updatedRecipeTags,
+        };
+      case actions.SET_IMAGE:
+        return {
+          ...state,
+          previewImage: [...state.previewImage, ...action.value],
         };
       case actions.UPDATE_INGREDIENT:
         setInputError(
@@ -285,6 +291,10 @@ const EditRecipeModal = ({
   };
 
   const handleNewImages = (selectedImages: Set<string>) => {
+    dispatch({
+      type: actions.SET_IMAGE,
+      value: selectedImages,
+    });
   };
 
   return (
@@ -377,9 +387,18 @@ const EditRecipeModal = ({
                     </Grid>
                   </Grid>
                 </Box>
-                <Button onClick={() => setImageSearchModalOpen(true)}>
-                  Add Images!
-                </Button>
+                <Box sx={{ display: "flex", gap: 2, overflowX: "auto" }}>
+                  {editedRecipeData.previewImage?.map((imageUrl, index) => (
+                    <AspectRatio ratio={1} sx={{ width: 250 }} key={index}>
+                      <img src={imageUrl} />
+                    </AspectRatio>
+                  ))}
+                  <AspectRatio ratio={1} sx={{ width: 250 }}>
+                    <Button onClick={() => setImageSearchModalOpen(true)}>
+                      Add Images!
+                    </Button>
+                  </AspectRatio>
+                </Box>
                 <TitledListView
                   itemsList={editedRecipeData.ingredients}
                   headerList={[

--- a/frontend/src/components/recipeDiff/EditRecipeModal.tsx
+++ b/frontend/src/components/recipeDiff/EditRecipeModal.tsx
@@ -23,6 +23,7 @@ import {
 } from "@mui/joy";
 import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutline";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import DeleteIcon from "@mui/icons-material/Delete";
 import TitledListView from "../utils/TitledListView";
 import {
   MUI_GRID_FULL_SPACE,
@@ -44,7 +45,8 @@ type GPEditRecipeModalType = {
 const actions = {
   SET_RECIPE: "setRecipe",
   SET_INPUT: "setInput",
-  SET_IMAGE: "setImage",
+  ADD_IMAGE: "addImage",
+  DELETE_IMAGE: "deleteImage",
   SET_INPUT_NUM: "setInputNum",
   SET_DIETARY_TAGS: "toggleTag",
   UPDATE_INGREDIENT: "setIngredient",
@@ -126,8 +128,12 @@ const EditRecipeModal = ({
         value: string;
       }
     | {
-        type: typeof actions.SET_IMAGE;
+        type: typeof actions.ADD_IMAGE;
         value: Set<string>;
+      }
+    | {
+        type: typeof actions.DELETE_IMAGE;
+        value: string;
       }
     | {
         type: typeof actions.SET_INPUT_NUM;
@@ -191,10 +197,17 @@ const EditRecipeModal = ({
           [action.dietTag]: !state[action.dietTag],
           recipeTags: updatedRecipeTags,
         };
-      case actions.SET_IMAGE:
+      case actions.ADD_IMAGE:
         return {
           ...state,
           previewImage: [...state.previewImage, ...action.value],
+        };
+      case actions.DELETE_IMAGE:
+        return {
+          ...state,
+          previewImage: state.previewImage.filter(
+            (imageUrl) => imageUrl !== action.value
+          ),
         };
       case actions.UPDATE_INGREDIENT:
         setInputError(
@@ -292,7 +305,7 @@ const EditRecipeModal = ({
 
   const handleNewImages = (selectedImages: Set<string>) => {
     dispatch({
-      type: actions.SET_IMAGE,
+      type: actions.ADD_IMAGE,
       value: selectedImages,
     });
   };
@@ -388,12 +401,28 @@ const EditRecipeModal = ({
                   </Grid>
                 </Box>
                 <Box sx={{ display: "flex", gap: 2, overflowX: "auto" }}>
-                  {editedRecipeData.previewImage?.map((imageUrl, index) => (
-                    <AspectRatio ratio={1} sx={{ width: 250 }} key={index}>
-                      <img src={imageUrl} />
-                    </AspectRatio>
-                  ))}
-                  <AspectRatio ratio={1} sx={{ width: 250 }}>
+                  <Box sx={{ display: "flex", gap: 2 }}>
+                    {editedRecipeData.previewImage?.map((imageUrl, index) => (
+                      <Box key={index}>
+                        <AspectRatio ratio={1} sx={{ width: 250 }}>
+                          <img src={imageUrl} />
+                        </AspectRatio>
+                        <Button
+                          variant="solid"
+                          sx={{ position: "relative", bottom: 45, left: 10 }}
+                          onClick={() =>
+                            dispatch({
+                              type: actions.DELETE_IMAGE,
+                              value: imageUrl,
+                            })
+                          }
+                        >
+                          <DeleteIcon />
+                        </Button>
+                      </Box>
+                    ))}
+                  </Box>
+                  <AspectRatio ratio={1} sx={{ minWidth: 250 }}>
                     <Button onClick={() => setImageSearchModalOpen(true)}>
                       Add Images!
                     </Button>

--- a/frontend/src/components/recipeDiff/ImageSearchModal.tsx
+++ b/frontend/src/components/recipeDiff/ImageSearchModal.tsx
@@ -1,0 +1,146 @@
+import {
+  Box,
+  Modal,
+  ModalDialog,
+  ModalClose,
+  DialogContent,
+  Button,
+  Input,
+  FormControl,
+  FormLabel,
+  Grid,
+  AspectRatio,
+} from "@mui/joy";
+import axios from "axios";
+import { useState } from "react";
+import type {
+  GPErrorMessageTypes,
+  GPPexelsImageType,
+} from "../../utils/types/types";
+import ErrorState from "../utils/ErrorState";
+import TitledListView from "../utils/TitledListView";
+import { CenteredTitledListStyle, GPCenteredBoxStyle, GPModalStyle, MUI_GRID_FULL_SPACE } from "../../utils/style/UIStyle";
+const IMAGE_API_KEY = import.meta.env.VITE_IMAGE_API_KEY;
+
+type GPImageSearchModalTypes = {
+  modalOpen: boolean;
+  toggleModal: () => void;
+  onSubmit: (value: Set<string>) => void;
+};
+
+const ImageSearchModal = ({
+  modalOpen,
+  toggleModal,
+  onSubmit,
+}: GPImageSearchModalTypes) => {
+  const [imageSearchTerm, setImageSearchTerm] = useState<string>("");
+  const [message, setMessage] = useState<GPErrorMessageTypes>();
+  const [imageSearchResults, setImageSearchResults] = useState<string[]>([]);
+  const [selectedImages, setSelectedImages] = useState<Set<string>>(new Set());
+
+  const handleSearchSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    try {
+      const imageResults = await axios.get(`https://api.pexels.com/v1/search`, {
+        headers: {
+          Authorization: IMAGE_API_KEY,
+        },
+        params: {
+          query: imageSearchTerm,
+          per_page: 6,
+        },
+      });
+      const photosArray = imageResults.data.photos;
+      const photosSrc = photosArray.map(
+        (photoInfo: GPPexelsImageType) => photoInfo.src?.large
+      );
+      setImageSearchResults(photosSrc);
+    } catch (error) {
+      setMessage({ error: true, message: "Error fetching images from API" });
+    }
+  };
+
+  const onImageSelect = (imageUrl: string) => {
+    if (selectedImages.has(imageUrl)) {
+      setSelectedImages((prev) => {
+        prev.delete(imageUrl);
+        return new Set(prev);
+      });
+    } else {
+      setSelectedImages((prev) => new Set(prev.add(imageUrl)));
+    }
+  };
+
+  const handleImageConfirmation = () => {
+    toggleModal()
+    onSubmit(selectedImages);
+  };
+
+  return (
+    <Modal
+      aria-labelledby="modal-title"
+      aria-describedby="modal-desc"
+      open={modalOpen}
+      onClose={toggleModal}
+    >
+      <ModalDialog sx={GPModalStyle}>
+        <ModalClose variant="plain" sx={{ zIndex: 2, m: 1 }} />
+        <DialogContent sx={{ my: 3 }}>
+          <form onSubmit={handleSearchSubmit}>
+            <Grid container alignItems="flex-end">
+                <Grid xs={10}>
+            <FormControl>
+              <FormLabel>Search Images</FormLabel>
+              <Input
+                slotProps={{
+                  input: { "data-reciperequest": "recipeName" },
+                }}
+                onChange={(event) => setImageSearchTerm(event.target.value)}
+                value={imageSearchTerm}
+                required
+              />
+            </FormControl>
+            </Grid>
+            <Grid xs={2}>
+            <Button type="submit">Search!</Button>
+                </Grid>
+                </Grid>
+          </form>
+          {message && (
+            <ErrorState error={message.error} message={message.message} />
+          )}
+          <Box display="flex" flexDirection="column" gap={2}>
+            {
+              <TitledListView
+                itemsList={imageSearchResults}
+                renderItem={(imageUrl, index) => (
+                  <AspectRatio
+                    onClick={() => onImageSelect(imageUrl)}
+                    ratio={1}
+                    key={index}
+                    sx={{
+                      ...(selectedImages.has(imageUrl) && {
+                        border: "4px solid", borderColor: "primary.300"
+                      }),
+                      width: 125
+                    }}
+                  >
+                    <img src={imageUrl} alt={imageSearchTerm} />
+                  </AspectRatio>
+                )}
+                listItemsStyle={CenteredTitledListStyle}
+              />
+            }
+            {imageSearchResults.length > 0 && (
+              <Button sx={{justifySelf: "center"}} onClick={handleImageConfirmation}>
+                Confirm Selection!
+              </Button>
+            )}
+          </Box>
+        </DialogContent>
+      </ModalDialog>
+    </Modal>
+  );
+};
+
+export default ImageSearchModal;

--- a/frontend/src/components/recipeDiff/ImageSearchModal.tsx
+++ b/frontend/src/components/recipeDiff/ImageSearchModal.tsx
@@ -74,6 +74,7 @@ const ImageSearchModal = ({
   const handleImageConfirmation = () => {
     toggleModal()
     onSubmit(selectedImages);
+    setSelectedImages(new Set())
   };
 
   return (

--- a/frontend/src/components/recipeDiff/RecipeDiffModal.tsx
+++ b/frontend/src/components/recipeDiff/RecipeDiffModal.tsx
@@ -52,7 +52,7 @@ const RecipeDiffModal = ({
                     Servings: {recipeDiffData?.recipeA?.servings}
                   </Typography>
                 </Box>
-                <img src={recipeDiffData?.recipeA?.previewImage} />
+                <img src={recipeDiffData?.recipeA?.previewImage[0]} />
               </Box>
             </Grid>
             <Grid xs={6}>
@@ -73,7 +73,7 @@ const RecipeDiffModal = ({
                     Servings: {recipeDiffData?.recipeB?.servings}
                   </Typography>
                 </Box>
-                <img src={recipeDiffData?.recipeB?.previewImage} />
+                <img src={recipeDiffData?.recipeB?.previewImage[0]} />
               </Box>
             </Grid>
           </Grid>

--- a/frontend/src/components/recipeDisplay/ImageCarousel.tsx
+++ b/frontend/src/components/recipeDisplay/ImageCarousel.tsx
@@ -1,0 +1,24 @@
+import { Box, AspectRatio } from "@mui/joy"; 
+
+type GPImageCarouselTypes = {
+    imageUrls: string[]
+}
+
+const ImageCarousel = ({imageUrls}: GPImageCarouselTypes)  => {
+  return (
+    <Box sx={{ display: "flex", overflowX: "auto", gap: 2 }}>
+      {imageUrls.map((imageUrl, index) => (
+        <Box key={index}>
+          <AspectRatio
+            ratio="1"
+            sx={{ maxWidth: 225, width: 225, borderRadius: "md" }}
+          >
+            <img src={imageUrl} />
+          </AspectRatio>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default ImageCarousel;

--- a/frontend/src/components/recipeDisplay/MealCard.tsx
+++ b/frontend/src/components/recipeDisplay/MealCard.tsx
@@ -149,7 +149,7 @@ const MealCard: React.FC<GPMealCardProps> = ({
           </Typography>
         </Box>
         <AspectRatio>
-          <img src={parsedMealData.previewImage} />
+          <img src={parsedMealData.previewImage[0]} />
         </AspectRatio>
         <CardContent sx={{ justifyContent: "flex-end" }}>
           {parsedMealData.editingAuthorName && (

--- a/frontend/src/components/recipeDisplay/MealInfoModal.tsx
+++ b/frontend/src/components/recipeDisplay/MealInfoModal.tsx
@@ -25,6 +25,7 @@ import { useState } from "react";
 import DiffOriginalRecipe from "../recipeDiff/DiffOriginalRecipe";
 import { Recipe } from "../../../../shared/Recipe";
 import UserDiffOptions from "../recipeDiff/UserDiffOptions";
+import ImageCarousel from "./ImageCarousel";
 
 type GPMealModalProps = {
   modalOpen: boolean;
@@ -42,7 +43,7 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
   const [originalRecipeInfo, setOriginalRecipeInfo] = useState<Recipe>();
   const [userDiffOptionsOpen, setUserDiffOptionsOpen] = useState(false);
   const [userDiffChoices, setUserDiffChoices] = useState<Set<string>>(
-    new Set(),
+    new Set()
   );
   const [noDiffFields, setNoDiffFields] = useState<Set<string>>(new Set());
 
@@ -52,7 +53,7 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
 
   const onSubmitUserDiffOptions = async (
     userChoices: Set<string>,
-    noDiffFields: Set<string>,
+    noDiffFields: Set<string>
   ) => {
     // we are viewing the edited recipe, need to fetch original recipe
     setUserDiffOptionsOpen(false);
@@ -82,10 +83,8 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
         sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
       >
         <Sheet variant="outlined" sx={GPModalStyle}>
+          <ImageCarousel imageUrls={recipeInfo?.previewImage ?? []} />
           <Box sx={GPMealInfoModalTitleStyle}>
-            <AspectRatio ratio="1"  sx={{ maxWidth: 300, width: 300, borderRadius: "md" }}>
-              <img src={recipeInfo?.previewImage[0]} />
-            </AspectRatio>
             <Box sx={GPCenteredBoxStyle}>
               <Typography level="h2">{recipeInfo?.recipeTitle}</Typography>
               {recipeInfo?.editingAuthorName && (

--- a/frontend/src/components/recipeDisplay/MealInfoModal.tsx
+++ b/frontend/src/components/recipeDisplay/MealInfoModal.tsx
@@ -84,7 +84,7 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
         <Sheet variant="outlined" sx={GPModalStyle}>
           <Box sx={GPMealInfoModalTitleStyle}>
             <AspectRatio ratio="1"  sx={{ maxWidth: 300, width: 300, borderRadius: "md" }}>
-              <img src={recipeInfo?.previewImage} />
+              <img src={recipeInfo?.previewImage[0]} />
             </AspectRatio>
             <Box sx={GPCenteredBoxStyle}>
               <Typography level="h2">{recipeInfo?.recipeTitle}</Typography>

--- a/frontend/src/pages/RecipeDiscoveryPage.tsx
+++ b/frontend/src/pages/RecipeDiscoveryPage.tsx
@@ -162,7 +162,7 @@ const RecipeDiscoveryPage = () => {
           />
         ))}
       </Box>
-      {message && (
+      {user && message && (
         <ErrorState error={message.error} message={message.message} />
       )}
       <MealInfoModal

--- a/frontend/src/utils/types/types.ts
+++ b/frontend/src/utils/types/types.ts
@@ -9,7 +9,7 @@ type GPRecipeDataTypes = {
   editingAuthorName: string;
   editingAuthorId: number | null;
   recipeTitle: string;
-  previewImage: string;
+  previewImage: string[];
   servings: number;
   ingredients: GPIngredientDataTypes[];
   instructions: string[];
@@ -95,6 +95,29 @@ type GPRecipeDiscoveryCategories = {
   vegan: Recipe[];
 };
 
+type GPPexelsImageType = {
+  id: number;
+  width: number;
+  height: number;
+  url: string;
+  photographer: string;
+  photographer_url: string;
+  photographer_id: number;
+  avg_color: string;
+  src: {
+    original: string;
+    large2x: string;
+    large: string;
+    medium: string;
+    small: string;
+    portrait: string;
+    landscape: string;
+    tiny: string;
+  };
+  liked: boolean;
+  alt: string;
+};
+
 export type {
   GPAccountInfoTypes,
   GPCurrentUserTypes,
@@ -107,4 +130,5 @@ export type {
   GPUserEventTypes,
   GPRecipeEventOptionType,
   GPRecipeDiscoveryCategories,
+  GPPexelsImageType
 };

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -18,14 +18,14 @@ const parseRecipeData = async (recipeData: any) => {
     recipeData.map(async (recipe: any) => {
       const parsedIngredients = parseIngredients(recipe.extendedIngredients);
       const parsedInstructions = parseInstructions(
-        recipe.analyzedInstructions[0].steps,
+        recipe.analyzedInstructions[0].steps
       );
       const parsedTags = parseTags(recipe);
       const newRecipe = new Recipe(
         recipe.id,
         recipe.sourceName,
         recipe.title,
-        recipe.image,
+        [recipe.image],
         recipe.servings,
         parsedIngredients,
         parsedInstructions,
@@ -36,10 +36,10 @@ const parseRecipeData = async (recipeData: any) => {
         recipe.glutenFree,
         recipe.dairyFree,
         parsedTags,
-        null,
+        null
       );
       return newRecipe;
-    }),
+    })
   );
 };
 
@@ -94,7 +94,7 @@ const estimateRecipeCost = async ({
     const response = await axios.post(
       `${databaseUrl}/generateList/estimateCost`,
       { ownedIngredients, recipeIngredients },
-      axiosConfig,
+      axiosConfig
     );
     return response.data;
   } catch (error) {
@@ -119,7 +119,7 @@ const validateInput = (formData: AuthFormData) => {
 
 const handleAuthInputChange = (
   event: React.ChangeEvent<HTMLInputElement>,
-  setFormData: React.Dispatch<React.SetStateAction<AuthFormData>>,
+  setFormData: React.Dispatch<React.SetStateAction<AuthFormData>>
 ) => {
   const credential = event.target.dataset.credential as GPAuthFormType;
   const value = event.target.value;
@@ -142,7 +142,7 @@ const parseGroceryListDepartments = (groceryList: GPIngredientDataTypes[]) => {
 
 type GPUpdateRecipePricingTypes = {
   setMessage: (
-    value: React.SetStateAction<GPErrorMessageTypes | undefined>,
+    value: React.SetStateAction<GPErrorMessageTypes | undefined>
   ) => void;
   recipe: Recipe;
 };

--- a/shared/Recipe.ts
+++ b/shared/Recipe.ts
@@ -8,7 +8,7 @@ class Recipe {
   readonly editingAuthorName: string;
   readonly editingAuthorId: number | null;
   readonly recipeTitle: string;
-  readonly previewImage: string;
+  readonly previewImage: string[];
   readonly servings: number;
   readonly ingredients: GPIngredientDataTypes[];
   readonly instructions: string[];
@@ -27,7 +27,7 @@ class Recipe {
     apiId: number,
     originalSource: string,
     recipeTitle: string,
-    previewImage: string,
+    previewImage: string[],
     servings: number,
     ingredients: GPIngredientDataTypes[],
     instructions: string[],


### PR DESCRIPTION
## Description

<what this pull request is doing>

- allows a user to add and delete images when editing a recipe
- create a modal to integrate the pexels api search results
- allow the user to add images without having to manually past urls
- Modifying the meal card into to have a carousel view as opposed to a single image

<what will be done in later PRs and not included here>

- further styling of the images presented and onclick functionality when selecting images

## Milestones
<the milestones or stories/features that this works towards>

- tc2, support for multiple media

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
https://www.pexels.com/api/documentation/?

## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
<div>
    <a href="https://www.loom.com/share/199667e2d9354314a4014428d7ccefd8">
      <p>Support for multiple images demo - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/199667e2d9354314a4014428d7ccefd8">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/199667e2d9354314a4014428d7ccefd8-16b623cfee1ebb53-full-play.gif">
    </a>
  </div>