### PR TITLE
Fill substitute info

### DIFF
--- a/frontend/src/components/editRecipe/EditRecipeModal.tsx
+++ b/frontend/src/components/editRecipe/EditRecipeModal.tsx
@@ -303,9 +303,9 @@ const EditRecipeModal = ({
       case actions.ADD_SUBSTITUTE_INSTRUCTIONS:
         // go through instructions and replace all instances of original ingredient with new ingredient
         const replacedInstructions = state.instructions.map((instruction) =>
-          instruction.replace(
-            action.originalIngredient,
-            action.substituteIngredient
+          instruction.toLowerCase().replace(
+            `${action.originalIngredient.toLowerCase()} `,
+            `${action.substituteIngredient.toLowerCase()} `
           )
         );
         return {

--- a/frontend/src/components/editRecipe/EditRecipeModal.tsx
+++ b/frontend/src/components/editRecipe/EditRecipeModal.tsx
@@ -303,10 +303,12 @@ const EditRecipeModal = ({
       case actions.ADD_SUBSTITUTE_INSTRUCTIONS:
         // go through instructions and replace all instances of original ingredient with new ingredient
         const replacedInstructions = state.instructions.map((instruction) =>
-          instruction.toLowerCase().replace(
-            `${action.originalIngredient.toLowerCase()} `,
-            `${action.substituteIngredient.toLowerCase()} `
-          )
+          instruction
+            .toLowerCase()
+            .replace(
+              `${action.originalIngredient.toLowerCase()} `,
+              `${action.substituteIngredient.toLowerCase()} `
+            )
         );
         return {
           ...state,
@@ -408,6 +410,7 @@ const EditRecipeModal = ({
       substitution.substitutionIngredients.length > 0 &&
       substitution.substitutionInstructions.length > 0
     ) {
+      const subIngredients: IngredientData[] = [];
       substitution.substitutionIngredients.map((ingredient) => {
         const substitutionIngredient = new IngredientData(
           0,
@@ -417,11 +420,22 @@ const EditRecipeModal = ({
           "",
           false
         );
-        dispatch({
-          type: actions.ADD_ITEM,
-          addedField: "ingredients",
-          addedItem: substitutionIngredient,
-        });
+        subIngredients.push(substitutionIngredient);
+      });
+      const substituteAsIngredient = new IngredientData(
+        0,
+        substitution.substitutionTitle,
+        substitution.substitutionQuantity,
+        substitution.substitutionUnit,
+        "",
+        false,
+        null,
+        subIngredients
+      );
+      dispatch({
+        type: actions.ADD_ITEM,
+        addedField: "ingredients",
+        addedItem: substituteAsIngredient,
       });
       // add instructions to the start of the recipe since we must create prior to using ingredient
       dispatch({

--- a/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
+++ b/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
@@ -4,30 +4,37 @@ import {
   AccordionDetails,
   AccordionGroup,
   AccordionSummary,
-  Box,
-  IconButton,
   Typography,
 } from "@mui/joy";
 import SubstitutionOption from "./SubstitutionOption";
 import type { IngredientSubstitutes } from "../../classes/ingredients/IngredientSubstitutes";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import type { IngredientData } from "../../../../shared/IngredientData";
 
 type GPSubstitutionOptionsType = {
   ingredientIndex: number;
-  substitutionOptions: IngredientSubstitutes[];
-  onSubstitutionSelect: (option: IngredientSubstitutes, index: number) => void;
+  originalIngredient: IngredientData;
+  onSubstitutionSelect: (
+    option: IngredientSubstitutes,
+    index: number,
+    originalIngredientName: string
+  ) => void;
 };
 
 const SubstitutionOptionsDropdown = ({
   ingredientIndex,
-  substitutionOptions,
+  originalIngredient,
   onSubstitutionSelect,
 }: GPSubstitutionOptionsType) => {
   const handleSelectSubstitution = (
     option: IngredientSubstitutes,
     ingredientIndex: number
   ) => {
-    onSubstitutionSelect(option, ingredientIndex);
+    onSubstitutionSelect(
+      option,
+      ingredientIndex,
+      originalIngredient.ingredientName
+    );
   };
 
   return (
@@ -55,7 +62,7 @@ const SubstitutionOptionsDropdown = ({
         },
       })}
     >
-      {substitutionOptions.map((option, index) => (
+      {originalIngredient.ingredientSubstitutes.map((option, index) => (
         <Accordion key={index}>
           <AccordionSummary
             sx={{
@@ -65,14 +72,12 @@ const SubstitutionOptionsDropdown = ({
               alignItems: "center",
             }}
           >
-            <Typography
-              sx={{ display: "flex", gap: 5, alignItems: "center" }}
-              onClick={(event) => {
-                event.stopPropagation();
-                handleSelectSubstitution(option, ingredientIndex);
-              }}
-            >
+            <Typography sx={{ display: "flex", gap: 5, alignItems: "center" }}>
               <CheckCircleOutlineIcon
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleSelectSubstitution(option, ingredientIndex);
+                }}
                 sx={{
                   color: "primary.500",
                   "&:hover": { color: "success.200" },

--- a/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
+++ b/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
@@ -4,7 +4,9 @@ import {
   AccordionDetails,
   AccordionGroup,
   AccordionSummary,
+  Box,
   IconButton,
+  Typography,
 } from "@mui/joy";
 import SubstitutionOption from "./SubstitutionOption";
 import type { IngredientSubstitutes } from "../../classes/ingredients/IngredientSubstitutes";
@@ -21,7 +23,10 @@ const SubstitutionOptionsDropdown = ({
   substitutionOptions,
   onSubstitutionSelect,
 }: GPSubstitutionOptionsType) => {
-  const handleSelectSubstitution = (option: IngredientSubstitutes, ingredientIndex: number) => {
+  const handleSelectSubstitution = (
+    option: IngredientSubstitutes,
+    ingredientIndex: number
+  ) => {
     onSubstitutionSelect(option, ingredientIndex);
   };
 
@@ -60,16 +65,21 @@ const SubstitutionOptionsDropdown = ({
               alignItems: "center",
             }}
           >
-            <IconButton
-              sx={{ "&:hover": { color: "success.200" } }}
+            <Typography
+              sx={{ display: "flex", gap: 5, alignItems: "center" }}
               onClick={(event) => {
                 event.stopPropagation();
                 handleSelectSubstitution(option, ingredientIndex);
               }}
             >
-              <CheckCircleOutlineIcon />
-            </IconButton>
-            {option.substitutionTitle}
+              <CheckCircleOutlineIcon
+                sx={{
+                  color: "primary.500",
+                  "&:hover": { color: "success.200" },
+                }}
+              />
+              {option.substitutionTitle}
+            </Typography>
           </AccordionSummary>
           <AccordionDetails>
             <SubstitutionOption optionData={option} />

--- a/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
+++ b/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
@@ -4,44 +4,76 @@ import {
   AccordionDetails,
   AccordionGroup,
   AccordionSummary,
+  IconButton,
 } from "@mui/joy";
 import SubstitutionOption from "./SubstitutionOption";
 import type { IngredientSubstitutes } from "../../classes/ingredients/IngredientSubstitutes";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 
 type GPSubstitutionOptionsType = {
+  ingredientIndex: number;
   substitutionOptions: IngredientSubstitutes[];
+  onSubstitutionSelect: (option: IngredientSubstitutes, index: number) => void;
 };
 
 const SubstitutionOptionsDropdown = ({
+  ingredientIndex,
   substitutionOptions,
+  onSubstitutionSelect,
 }: GPSubstitutionOptionsType) => {
+  const handleSelectSubstitution = (option: IngredientSubstitutes, ingredientIndex: number) => {
+    onSubstitutionSelect(option, ingredientIndex);
+  };
+
   return (
     // Accordion styling adapted from: https://mui.com/joy-ui/react-accordion/
-    <AccordionGroup sx={(theme) => ({
+    <AccordionGroup
+      sx={(theme) => ({
         [`& .${accordionClasses.root}`]: {
-          marginTop: '0.5rem',
-          transition: '0.2s ease',
+          marginTop: "0.5rem",
+          transition: "0.2s ease",
           '& button:not([aria-expanded="true"])': {
-            transition: '0.2s ease',
-            paddingBottom: '0.625rem',
+            transition: "0.2s ease",
+            paddingBottom: "0.625rem",
           },
-          '& button:hover': {
-            background: 'transparent',
+          "& button:hover": {
+            background: "transparent",
           },
         },
         [`& .${accordionClasses.root}.${accordionClasses.expanded}`]: {
-          borderRadius: 'md',
-          border: '2px solid',
-          borderColor: 'primary.400',
+          borderRadius: "md",
+          border: "2px solid",
+          borderColor: "primary.400",
         },
         '& [aria-expanded="true"]': {
           boxShadow: `inset 0 -1px 0 ${theme.vars.palette.divider}`,
         },
-      })}>
+      })}
+    >
       {substitutionOptions.map((option, index) => (
         <Accordion key={index}>
-          <AccordionSummary>{option.substitutionTitle}</AccordionSummary>
-          <AccordionDetails><SubstitutionOption optionData={option} /></AccordionDetails>
+          <AccordionSummary
+            sx={{
+              width: "100%",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <IconButton
+              sx={{ "&:hover": { color: "success.200" } }}
+              onClick={(event) => {
+                event.stopPropagation();
+                handleSelectSubstitution(option, ingredientIndex);
+              }}
+            >
+              <CheckCircleOutlineIcon />
+            </IconButton>
+            {option.substitutionTitle}
+          </AccordionSummary>
+          <AccordionDetails>
+            <SubstitutionOption optionData={option} />
+          </AccordionDetails>
         </Accordion>
       ))}
     </AccordionGroup>

--- a/frontend/src/components/ingredients/IngredientModal.tsx
+++ b/frontend/src/components/ingredients/IngredientModal.tsx
@@ -52,7 +52,8 @@ const IngredientModal: React.FC<GPIngredientModalProps> = ({
   const [ingredientInputError, setIngredientInputError] = useState(false);
 
   const initialIngredientState =
-    ingredientData ?? new IngredientData(0, "", 0, "", "", false, null, 0, "");
+    ingredientData ??
+    new IngredientData(0, "", 0, "", "", false, null, [], 0, "");
 
   type ACTIONTYPE =
     | {

--- a/frontend/src/components/recipeDisplay/MealInfoModal.tsx
+++ b/frontend/src/components/recipeDisplay/MealInfoModal.tsx
@@ -81,12 +81,12 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
 
   const onSubstituteClick = () => {
     setEditRecipeModalOpen(true);
-    toggleModal()
+    toggleModal();
   };
 
   const handleCreateSubstitutionRecipe = () => {
     setEditRecipeModalOpen(false);
-    refreshRecipes && refreshRecipes()
+    refreshRecipes && refreshRecipes();
   };
 
   return (
@@ -152,6 +152,25 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
                         {ingredient.unit}
                       </Typography>
                     </ListItemContent>
+                    {ingredient.subIngredients && (
+                      <List sx={{ ml: 4 }} marker="disc">
+                        {ingredient.subIngredients.map((subIngredient) => (
+                          <ListItem key={subIngredient.ingredientName}>
+                            <Typography>
+                              {subIngredient.ingredientName}
+                            </Typography>
+                            <Typography>
+                              {subIngredient.quantity % 1 === 0
+                                ? subIngredient.quantity
+                                : Number(subIngredient.quantity).toFixed(
+                                    2
+                                  )}{" "}
+                              {subIngredient.unit}
+                            </Typography>
+                          </ListItem>
+                        ))}
+                      </List>
+                    )}
                   </ListItem>
                 );
               })}

--- a/frontend/src/components/recipeDisplay/MealInfoModal.tsx
+++ b/frontend/src/components/recipeDisplay/MealInfoModal.tsx
@@ -32,12 +32,14 @@ type GPMealModalProps = {
   modalOpen: boolean;
   toggleModal: () => void;
   recipeInfo: Recipe | undefined;
+  refreshRecipes?: () => void;
 };
 
 const MealInfoModal: React.FC<GPMealModalProps> = ({
   toggleModal,
   modalOpen,
   recipeInfo,
+  refreshRecipes,
 }) => {
   const [_, setMessage] = useState<GPErrorMessageTypes>();
   const [diffModalOpen, setDiffModalOpen] = useState(false);
@@ -78,16 +80,13 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
   };
 
   const onSubstituteClick = () => {
-    // open edit meal modal
     setEditRecipeModalOpen(true);
-    // add all recipe information
-    // to the side of each ingredient have a "suggest substitutes" button
+    toggleModal()
   };
 
   const handleCreateSubstitutionRecipe = () => {
-    // close modal
     setEditRecipeModalOpen(false);
-    // set the newly updated recipe modal open
+    refreshRecipes && refreshRecipes()
   };
 
   return (

--- a/frontend/src/pages/RecipeDiscoveryPage.tsx
+++ b/frontend/src/pages/RecipeDiscoveryPage.tsx
@@ -245,6 +245,7 @@ const RecipeDiscoveryPage = () => {
           toggleModal={() => setRecipeInfoModalOpen((prev) => !prev)}
           modalOpen={recipeInfoModalOpen}
           recipeInfo={recipeInfoModalInfo}
+          refreshRecipes={() => fetchRecipesToDisplay()}
         />
         <EditRecipeModal
           recipe={editRecipeInfo}

--- a/frontend/src/utils/geminiApi.ts
+++ b/frontend/src/utils/geminiApi.ts
@@ -29,18 +29,17 @@ async function getSubstitutionForIngredient({
   const responseText = response.text;
   const prepForJson = responseText?.replace(/`/g, "").replace("json", "") ?? "";
   const asJson: GPAiSubstitutionReturnType[] = JSON.parse(prepForJson);
-  let substitutionResults: IngredientSubstitutes[] = [];
-  for (const substitute of asJson) {
-    const ingredientSubstitute = new IngredientSubstitutes(
-      substitute.substitutionTitle,
-      substitute.substitutionQuantity,
-      substitute.substitutionUnit,
-      substitute.storeBought,
-      substitute.substitutionIngredients,
-      substitute.substitutionInstructions
-    );
-    substitutionResults = [...substitutionResults, ingredientSubstitute];
-  }
+  const substitutionResults = asJson.map(
+    (substitute) =>
+      new IngredientSubstitutes(
+        substitute.substitutionTitle,
+        substitute.substitutionQuantity,
+        substitute.substitutionUnit,
+        substitute.storeBought,
+        substitute.substitutionIngredients,
+        substitute.substitutionInstructions
+      )
+  );
   return substitutionResults;
 }
 

--- a/shared/IngredientData.ts
+++ b/shared/IngredientData.ts
@@ -8,6 +8,7 @@ class IngredientData {
   readonly department: string;
   isChecked: boolean;
   expirationDate: string | null;
+  readonly subIngredients: IngredientData[];
   ingredientCost: number;
   ingredientCostUnit: string;
   ingredientSubstitutes: IngredientSubstitutes[];
@@ -20,6 +21,7 @@ class IngredientData {
     department: string,
     isChecked: boolean,
     expirationDate?: string | null,
+    subIngredients?: IngredientData[],
     ingredientCost?: number,
     ingredientCostUnit?: string,
     ingredientSubstitutes?: IngredientSubstitutes[]
@@ -31,6 +33,7 @@ class IngredientData {
     this.department = department;
     this.isChecked = isChecked;
     this.expirationDate = expirationDate ?? null;
+    this.subIngredients = subIngredients ?? [];
     this.ingredientCost = ingredientCost ?? 0;
     this.ingredientCostUnit = ingredientCostUnit ?? "";
     this.ingredientSubstitutes = ingredientSubstitutes ?? [];


### PR DESCRIPTION
## Description

<what this pull request is doing>

- allow a user to click to select which ingredient they would like to use for their substitution
- delete the original ingredient and add the new ingredient
- Replace any mentions of the previous ingredient within the instructions with the new ingredient
- If the substitution is homemade, display the ingredients and instructions needed to create substitute

<what will be done in later PRs and not included here>

- improving the usability and intuitiveness of the feature


## Milestones

<the milestones or stories/features that this works towards>

- TC3, dietary substitutions

## Resources

<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>

## Test Plan

<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
<div>
    <a href="https://www.loom.com/share/3d840b1a475e419fb500a41c624b8b4a">
      <p>Ingredient replacement demo - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/3d840b1a475e419fb500a41c624b8b4a">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/3d840b1a475e419fb500a41c624b8b4a-4ffb3aadae54646a-full-play.gif">
    </a>
  </div>