### PR TITLE
Grocery list adjustment

### DIFF
--- a/backend/routes/groceryListRoutes.ts
+++ b/backend/routes/groceryListRoutes.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { getListOfMissingIngredients, estimateListCost } from "../utils/utils";
+import {
+  getListOfMissingIngredients,
+  estimateListCost,
+  updateEstimatedListCost,
+} from "../utils/utils";
 
 const express = require("express");
 const router = express.Router();
@@ -43,10 +47,12 @@ router.put("/clear", isAuthenticated, async (req: Request, res: Response) => {
         return !ingredientItem.isChecked;
       }
     );
+    const updatedGroceryListPrice = updateEstimatedListCost({ingredientsToPurchase: clearedList});
     const updatedUser = await prisma.user.update({
       where: { id: userId },
       data: {
         groceryList: clearedList,
+        groceryListCost: updatedGroceryListPrice,
       },
     });
     res.json(updatedUser);

--- a/backend/utils/utils.ts
+++ b/backend/utils/utils.ts
@@ -267,7 +267,9 @@ const estimateListCost = async ({
         null,
         [],
         ingredientApiInfo.ingredientCost,
-        ingredientApiInfo.ingredientCostUnit
+        ingredientApiInfo.ingredientCostUnit,
+        [],
+        ingredientApiInfo.ingredientItemId
       ),
     ];
   }
@@ -287,9 +289,10 @@ const getCostForAmountOfIngredient = async ({
     const ingredientCost = searchResults.items[0]?.salePrice ?? 0;
     const ingredientCostUnit =
       searchResults.items[0]?.size ?? "Price not Found";
-    return { ingredientCost, ingredientCostUnit };
+    const ingredientItemId = searchResults.items[0]?.itemId ?? -1;
+    return { ingredientCost, ingredientCostUnit, ingredientItemId };
   } else {
-    return { ingredientCost: 0, ingredientCostUnit: "Price not Found" };
+    return { ingredientCost: 0, ingredientCostUnit: "Price not Found", ingredientItemId: -1 };
   }
 };
 

--- a/backend/utils/utils.ts
+++ b/backend/utils/utils.ts
@@ -191,6 +191,13 @@ const getListOfMissingIngredients = ({
  return ingredientsToPurchase;
 };
 
+const updateEstimatedListCost = ({ingredientsToPurchase}: GPEstimateListCostTypes) => {
+  let totalEstimatedCost = 0;
+  for (const ingredient of ingredientsToPurchase) {
+    totalEstimatedCost += ingredient.ingredientCost ?? 0
+  }
+  return totalEstimatedCost;
+}
 
 const checkIfIngredientIsOwned = (
  ingredientsToPurchase: IngredientData[],
@@ -318,4 +325,5 @@ export {
   estimateListCost,
   getLevenshteinDistance,
   fuzzyMatchIngredient,
+  updateEstimatedListCost,
 };

--- a/frontend/src/classes/ingredients/IngredientSubstitutes.ts
+++ b/frontend/src/classes/ingredients/IngredientSubstitutes.ts
@@ -2,11 +2,13 @@ type GPBasicIngredientInfoType = {
   ingredientName: string;
   quantity: number;
   unit: string;
+  department: string;
 };
 class IngredientSubstitutes {
   readonly substitutionTitle: string;
   readonly substitutionQuantity: number;
   readonly substitutionUnit: string;
+  readonly substitutionDepartment: string;
   readonly storeBought: boolean;
   readonly substitutionIngredients: GPBasicIngredientInfoType[];
   readonly substitutionInstructions: string[];
@@ -15,6 +17,7 @@ class IngredientSubstitutes {
     substitutionTitle: string,
     substitutionQuantity: number,
     substitutionUnit: string,
+    substitutionDepartment: string,
     storeBought: boolean,
     substitutionIngredients: GPBasicIngredientInfoType[],
     substitutionInstructions: string[]
@@ -22,6 +25,7 @@ class IngredientSubstitutes {
     this.substitutionTitle = substitutionTitle;
     this.substitutionQuantity = substitutionQuantity;
     this.substitutionUnit = substitutionUnit;
+    this.substitutionDepartment = substitutionDepartment;
     this.storeBought = storeBought;
     this.substitutionIngredients = substitutionIngredients;
     this.substitutionInstructions = substitutionInstructions;

--- a/frontend/src/components/GroceryListDepartment.tsx
+++ b/frontend/src/components/GroceryListDepartment.tsx
@@ -42,10 +42,6 @@ const GroceryListDepartment: React.FC<GPGroceryListDepartmentProps> = ({
             presentGroceryCheck={true}
             presentExpiration={false}
             presentButtons={false}
-            ingredientCost={{
-              ingredientCost: itemInfo?.ingredientCost ?? 0,
-              ingredientCostUnit: itemInfo.ingredientCostUnit ?? 0,
-            }}
             onGroceryCheck={onGroceryCheck}
           />
         )}

--- a/frontend/src/components/editRecipe/EditRecipeModal.tsx
+++ b/frontend/src/components/editRecipe/EditRecipeModal.tsx
@@ -417,7 +417,7 @@ const EditRecipeModal = ({
           ingredient.ingredientName,
           ingredient.quantity,
           ingredient.unit,
-          "",
+          ingredient.department,
           false
         );
         subIngredients.push(substitutionIngredient);
@@ -427,7 +427,7 @@ const EditRecipeModal = ({
         substitution.substitutionTitle,
         substitution.substitutionQuantity,
         substitution.substitutionUnit,
-        "",
+        substitution.substitutionDepartment,
         false,
         null,
         subIngredients
@@ -454,7 +454,7 @@ const EditRecipeModal = ({
           substitution.substitutionTitle,
           substitution.substitutionQuantity,
           substitution.substitutionUnit,
-          "",
+          substitution.substitutionDepartment,
           false
         ),
       });

--- a/frontend/src/components/ingredients/Ingredient.tsx
+++ b/frontend/src/components/ingredients/Ingredient.tsx
@@ -28,7 +28,6 @@ type GPIngredientProps = {
   presentGroceryCheck: boolean;
   presentExpiration: boolean;
   presentButtons: boolean;
-  ingredientCost?: GPIngredientApiInfoType;
   onGroceryCheck?: (ingredientName: string) => void;
   onEdit?: (ingredient: IngredientData) => void;
   onDelete?: (ingredient: IngredientData) => void;
@@ -38,7 +37,6 @@ const Ingredient: React.FC<GPIngredientProps> = ({
   ingredient,
   presentGroceryCheck,
   presentExpiration,
-  ingredientCost,
   presentButtons,
   onGroceryCheck,
   onEdit,
@@ -70,10 +68,10 @@ const Ingredient: React.FC<GPIngredientProps> = ({
             <Typography>{ingredient.expirationDate}</Typography>
           </Grid>
         )}
-        {ingredientCost && (
+        {ingredient.ingredientCost > 0 && (
           <Grid xs={GRID_NAME_COST_SPACING}>
             <Typography>
-              Est. ${ingredientCost.ingredientCost?.toFixed(2)}
+              Est. ${ingredient.ingredientCost.toFixed(2)}
             </Typography>
           </Grid>
         )}

--- a/frontend/src/components/ingredients/Ingredient.tsx
+++ b/frontend/src/components/ingredients/Ingredient.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
-import type { GPIngredientApiInfoType } from "../../utils/types/types";
 import {
   Box,
   ButtonGroup,
@@ -9,6 +8,7 @@ import {
   Grid,
   IconButton,
   Typography,
+  Link,
 } from "@mui/joy";
 import type { IngredientData } from "../../../../shared/IngredientData";
 
@@ -58,7 +58,7 @@ const Ingredient: React.FC<GPIngredientProps> = ({
           </Grid>
         )}
         <Grid xs={GRID_NAME_COST_SPACING}>
-          <Typography>{ingredient.ingredientName}</Typography>
+          {ingredient.ingredientWalmartId > 0 && presentGroceryCheck ? <Link href={`https://www.walmart.com/ip/${ingredient.ingredientWalmartId}`}>{ingredient.ingredientName}</Link> : <Typography>{ingredient.ingredientName}</Typography>}
         </Grid>
         <Grid xs={GRID_EXP_QUANT_SPACING}>
           <Typography>{`${formatQuantity} ${ingredient.unit}`}</Typography>

--- a/frontend/src/components/recipeDisplay/MealInfoModal.tsx
+++ b/frontend/src/components/recipeDisplay/MealInfoModal.tsx
@@ -156,17 +156,19 @@ const MealInfoModal: React.FC<GPMealModalProps> = ({
                       <List sx={{ ml: 4 }} marker="disc">
                         {ingredient.subIngredients.map((subIngredient) => (
                           <ListItem key={subIngredient.ingredientName}>
-                            <Typography>
-                              {subIngredient.ingredientName}
-                            </Typography>
-                            <Typography>
-                              {subIngredient.quantity % 1 === 0
-                                ? subIngredient.quantity
-                                : Number(subIngredient.quantity).toFixed(
-                                    2
-                                  )}{" "}
-                              {subIngredient.unit}
-                            </Typography>
+                            <Box sx={{display: "flex", justifyContent: "space-between"}}>
+                              <Typography>
+                                {subIngredient.ingredientName}
+                              </Typography>
+                              <Typography>
+                                {subIngredient.quantity % 1 === 0
+                                  ? subIngredient.quantity
+                                  : Number(subIngredient.quantity).toFixed(
+                                      2
+                                    )}{" "}
+                                {subIngredient.unit}
+                              </Typography>
+                            </Box>
                           </ListItem>
                         ))}
                       </List>

--- a/frontend/src/pages/GroceryList.tsx
+++ b/frontend/src/pages/GroceryList.tsx
@@ -62,7 +62,15 @@ const GroceryList = () => {
     <Box>
       <AppHeader />
       <Box sx={{ m: 3 }}>
-        <Button onClick={handleClearGroceries}>Clear Purchased Items</Button>
+        <Box sx={{display: "flex", alignItems: "flex-start", justifyContent: "space-between"}}>
+          <Button onClick={handleClearGroceries}>Clear Purchased Items</Button>
+          <Box textAlign="right">
+          <Typography level="h3">Estimated Cost</Typography>
+          <Typography level="h4">
+            ${Number(groceryListCost).toFixed(2)}
+          </Typography>
+          </Box>
+        </Box>
         <Box sx={{ my: 3 }}>
           <TitledListView
             itemsList={groceryDepartments}
@@ -77,10 +85,6 @@ const GroceryList = () => {
             listItemsStyle={CenteredTitledListStyle}
           />
         </Box>
-        <Typography level="h3">Estimated Cost</Typography>
-        <Typography level="h4">
-          ${Number(groceryListCost).toFixed(2)}
-        </Typography>
       </Box>
       {addGroceryItemModalOpen && (
         <IngredientModal

--- a/frontend/src/utils/geminiApi.ts
+++ b/frontend/src/utils/geminiApi.ts
@@ -19,7 +19,7 @@ async function getSubstitutionForIngredient({
 }: GPIngredientSubstituteTypes) {
   const response = await ai.models.generateContent({
     model: "gemini-2.5-flash",
-    contents: `Give me 3 substitutions for ${ingredient.quantity} ${ingredient.unit} of ${ingredient.ingredientName} for the intolerances and diets ${intolerancesAndDiets}, json formatted as { substitutionTitle: string, substitutionQuantity: number, substitutionUnit: string, storeBought: boolean, substitutionIngredients: [{ingredientName: string, quantity: number, unit: string}], substitutionInstructions: string[] } but if its storebought, then the substitutionIngredients and substitutionInstructions will be empty arrays`,
+    contents: `Give me 3 substitutions for ${ingredient.quantity} ${ingredient.unit} of ${ingredient.ingredientName} for the intolerances and diets ${intolerancesAndDiets}, json formatted as { substitutionTitle: string, substitutionQuantity: number, substitutionUnit: string, substitutionDepartment: string, storeBought: boolean, substitutionIngredients: [{ingredientName: string, quantity: number, unit: string, department: string}], substitutionInstructions: string[] } but if its storebought, then the substitutionIngredients and substitutionInstructions will be empty arrays`,
     config: {
       thinkingConfig: {
         thinkingBudget: 0, // Disables thinking
@@ -35,6 +35,7 @@ async function getSubstitutionForIngredient({
         substitute.substitutionTitle,
         substitute.substitutionQuantity,
         substitute.substitutionUnit,
+        substitute.substitutionDepartment,
         substitute.storeBought,
         substitute.substitutionIngredients,
         substitute.substitutionInstructions

--- a/frontend/src/utils/types/aiSubReturnType.ts
+++ b/frontend/src/utils/types/aiSubReturnType.ts
@@ -2,12 +2,14 @@ type GPAiSubstitutionReturnType = {
   substitutionTitle: string;
   substitutionQuantity: number;
   substitutionUnit: string;
+  substitutionDepartment: string;
   storeBought: boolean;
   substitutionIngredients: [
     {
       ingredientName: string;
       quantity: number;
       unit: string;
+      department: string;
     },
   ];
   substitutionInstructions: string[];

--- a/shared/IngredientData.ts
+++ b/shared/IngredientData.ts
@@ -12,6 +12,7 @@ class IngredientData {
   ingredientCost: number;
   ingredientCostUnit: string;
   ingredientSubstitutes: IngredientSubstitutes[];
+  ingredientWalmartId: number;
 
   constructor(
     id: number,
@@ -24,7 +25,8 @@ class IngredientData {
     subIngredients?: IngredientData[],
     ingredientCost?: number,
     ingredientCostUnit?: string,
-    ingredientSubstitutes?: IngredientSubstitutes[]
+    ingredientSubstitutes?: IngredientSubstitutes[],
+    ingredientWalmartId?: number
   ) {
     this.id = id;
     this.ingredientName = ingredientName;
@@ -37,6 +39,7 @@ class IngredientData {
     this.ingredientCost = ingredientCost ?? 0;
     this.ingredientCostUnit = ingredientCostUnit ?? "";
     this.ingredientSubstitutes = ingredientSubstitutes ?? [];
+    this.ingredientWalmartId = ingredientWalmartId ?? -1
   }
 }
 


### PR DESCRIPTION
## Description

<what this pull request is doing>

- enhance the user experience of the grocery list page via
    - accounting for "sub ingredients" if an ingredient requires preparation (used with ingredient substitutions) when estimating the grocery list price
    - updating the estimated cost to reflect remaining items on list after clearing the purchased ingredients
    - moving the estimated cost to the top of the page
    - add a link to the item on the walmart website

<what will be done in later PRs and not included here>

## Milestones

<the milestones or stories/features that this works towards>

- enhancing the user experience, small features

## Resources

<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>

## Test Plan

<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
<div>
    <a href="https://www.loom.com/share/dc9f297e3615440389038755941ae3e2">
      <p>Grocery list page features - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/dc9f297e3615440389038755941ae3e2">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/dc9f297e3615440389038755941ae3e2-e69e7e10eccae38c-full-play.gif">
    </a>
  </div>