### PR TITLE
Discovery page load more

### DIFF
--- a/backend/routes/recipeRoutes.ts
+++ b/backend/routes/recipeRoutes.ts
@@ -10,6 +10,18 @@ const prisma = new PrismaClient();
 import { isAuthenticated } from "../utils/authMiddleware";
 import { convertUnits } from "../utils/utils";
 
+router.post("/totalNumRecipes", async (req: Request, res: Response) => {
+  const { filter } = req.body;
+  try {
+    const numRecipes = await prisma.recipe.count({
+      ...(filter !== "all" ? { where: { [filter]: true } } : {}),
+    });
+    res.json(numRecipes);
+  } catch (error) {
+    res.status(500).send("Error fetching number of recipes in database");
+  }
+});
+
 router.post("/discover", async (req: Request, res: Response) => {
   const { filter, offset, numRequested } = req.body;
   try {
@@ -32,7 +44,7 @@ router.post("/popular", async (req: Request, res: Response) => {
   try {
     const mostPopular = await prisma.recipe.findMany({
       orderBy: {
-        likes: "desc"
+        likes: "desc",
       },
       skip: parseInt(offset),
       take: parseInt(numRequested),

--- a/frontend/src/components/recipeDisplay/MealCard.tsx
+++ b/frontend/src/components/recipeDisplay/MealCard.tsx
@@ -10,6 +10,7 @@ import {
   IconButton,
   AspectRatio,
   Link,
+  Grid,
 } from "@mui/joy";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
@@ -60,7 +61,7 @@ const MealCard: React.FC<GPMealCardProps> = ({
 }) => {
   const [ingredientCostModalOpen, setIngredientCostModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [currentLikes, setCurrentLikes] = useState(parsedMealData.likes)
+  const [currentLikes, setCurrentLikes] = useState(parsedMealData.likes);
 
   const toggleModal = () => {
     setIngredientCostModalOpen((prev) => !prev);
@@ -94,49 +95,49 @@ const MealCard: React.FC<GPMealCardProps> = ({
     <>
       {/* Code referenced from MUI Joy Documentation https://mui.com/joy-ui/react-card/#interactive-card*/}
       <Card variant="outlined">
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
-          <Typography level="h4">{parsedMealData.recipeTitle}</Typography>
-          <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
-            <Tooltip
-              title={favorited ? "Remove from favorites" : "Add to favorites"}
-            >
-              <IconButton
-                color="primary"
-                sx={{ zIndex: 2 }}
-                disabled={onFavoriteClick ? false : true}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  if (onFavoriteClick) {
-                    setCurrentLikes((prev) => favorited ? prev - 1 : prev + 1)
-                    onFavoriteClick(parsedMealData);
-                  }
-                }}
+        <Grid container sx={{ mr: 2 }}>
+          <Grid xs={10}>
+            <Typography level="h4">{parsedMealData.recipeTitle}</Typography>
+          </Grid>
+          <Grid xs={2}>
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <Tooltip
+                title={favorited ? "Remove from favorites" : "Add to favorites"}
               >
-                {favorited ? <FavoriteIcon /> : <FavoriteBorderIcon />}
-                <Typography>{currentLikes}</Typography>
-              </IconButton>
-            </Tooltip>
-            {onCompareSelect && (
-              <Tooltip title="Compare recipes">
-                <Checkbox
-                  sx={{ zIndex: 5 }}
-                  size="lg"
-                  checked={selectedToCompare}
+                <IconButton
+                  color="primary"
+                  sx={{ zIndex: 2 }}
+                  disabled={onFavoriteClick ? false : true}
                   onClick={(event) => {
                     event.stopPropagation();
-                    onCompareSelect(parsedMealData);
+                    if (onFavoriteClick) {
+                      setCurrentLikes((prev) =>
+                        favorited ? prev - 1 : prev + 1
+                      );
+                      onFavoriteClick(parsedMealData);
+                    }
                   }}
-                />
+                >
+                  {favorited ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+                  <Typography>{currentLikes}</Typography>
+                </IconButton>
               </Tooltip>
-            )}
-          </Box>
-        </Box>
+              {onCompareSelect && (
+                <Tooltip title="Compare recipes">
+                  <Checkbox
+                    sx={{ zIndex: 5 }}
+                    size="lg"
+                    checked={selectedToCompare}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onCompareSelect(parsedMealData);
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </Box>
+          </Grid>
+        </Grid>
         <Box sx={{ my: 0, display: "flex", justifyContent: "space-between" }}>
           <Typography>Servings: {parsedMealData.servings}</Typography>
           <Typography>

--- a/frontend/src/pages/RecipeDiscoveryPage.tsx
+++ b/frontend/src/pages/RecipeDiscoveryPage.tsx
@@ -51,7 +51,8 @@ const RecipeDiscoveryPage = () => {
   );
   const [displayedRecipes, setDisplayedRecipes] = useState<Recipe[]>([]);
   const [offset, setOffset] = useState(0);
-  const [loadingRecipes, setLoadingRecipes] = useState(false);
+  const [disableLoadMore, setDisableLoadMore] = useState(false);
+  const [totalNumRecipes, setTotalNumRecipes] = useState(0);
 
   useEffect(() => {
     fetchRecipesToDisplay();
@@ -69,6 +70,7 @@ const RecipeDiscoveryPage = () => {
       const popularRecipes =
         (await fetchPopularRecipes({
           setMessage,
+          setTotalNumRecipes,
           offset: offset,
           numRequested: MAX_RECIPES_TO_DISPLAY,
         })) ?? [];
@@ -80,6 +82,7 @@ const RecipeDiscoveryPage = () => {
     } else {
       const fetchedRecipes =
         (await fetchDiscoverRecipes({
+          setTotalNumRecipes,
           setMessage,
           filter: recipeFilter,
           offset: offset,
@@ -188,16 +191,17 @@ const RecipeDiscoveryPage = () => {
   };
 
   useEffect(() => {
+    setOffset(0)
     fetchRecipesToDisplay();
   }, [recipeFilter]);
 
   useEffect(() => {
     fetchRecipesToDisplay();
-    setLoadingRecipes(false);
-  }, [offset]);
+    setDisableLoadMore(offset + MAX_RECIPES_TO_DISPLAY > totalNumRecipes)
+  }, [offset, totalNumRecipes]);
 
   const handleLoadMoreRecipes = () => {
-    setLoadingRecipes(true);
+    setDisableLoadMore(true);
     setOffset((prev) => prev + MAX_RECIPES_TO_DISPLAY);
   };
 
@@ -257,14 +261,13 @@ const RecipeDiscoveryPage = () => {
               />
             ))}
           </Masonry>
-          <Button
-            disabled={loadingRecipes}
+          {!disableLoadMore && <Button
             sx={{ display: "block", margin: "auto", mt: 4 }}
             size="lg"
             onClick={() => handleLoadMoreRecipes()}
           >
             Load More Recipes!
-          </Button>
+          </Button>}
         </Box>
         {user && message && (
           <ErrorState error={message.error} message={message.message} />

--- a/shared/IngredientData.ts
+++ b/shared/IngredientData.ts
@@ -1,4 +1,3 @@
-import type { IngredientSubstitutes } from "../frontend/src/classes/ingredients/IngredientSubstitutes";
 import { GPAiSubstitutionReturnType } from "../frontend/src/utils/types/aiSubReturnType";
 
 class IngredientData {


### PR DESCRIPTION
## Description

<what this pull request is doing>

- enable a user to load more recipes on click of "load more recipes" button
- disable the load more button when no more recipes in database to display
- use prisma .count to count number of records and control load more button

<what will be done in later PRs and not included here>

## Milestones

<the milestones or stories/features that this works towards>

## Resources

<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
https://www.prisma.io/docs/orm/prisma-client/queries/aggregation-grouping-summarizing

## Test Plan

<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
<div>
    <a href="https://www.loom.com/share/b2526466841041daa18e351114cf2a91">
      <p>Load more demo - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/b2526466841041daa18e351114cf2a91">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b2526466841041daa18e351114cf2a91-ae26b0fdfcf2ad2f-full-play.gif">
    </a>
  </div>