### PR TITLE
Image diffing

### DIFF
--- a/frontend/src/classes/recipeDiffClasses/DiffRecipes.ts
+++ b/frontend/src/classes/recipeDiffClasses/DiffRecipes.ts
@@ -158,7 +158,7 @@ class DiffRecipes {
       this.recipeA.previewImage,
       this.recipeB.previewImage
     );
-    const imageDiffResults = diffImages.getStringArrayDiff();
+    const imageDiffResults = diffImages.getLcsDiff();
     return imageDiffResults;
   }
 

--- a/frontend/src/classes/recipeDiffClasses/DiffRecipes.ts
+++ b/frontend/src/classes/recipeDiffClasses/DiffRecipes.ts
@@ -10,6 +10,7 @@ const GPDiffOptionsEnum = {
   TAGS: "Recipe Tags",
   INGREDIENTS: "Ingredients",
   INSTRUCTIONS: "Instructions",
+  IMAGES: "Images",
 } as const;
 
 class DiffRecipes {
@@ -66,6 +67,10 @@ class DiffRecipes {
           const ingredientsDiffResults = this.getIngredientsDiff();
           requestedFields = { ...requestedFields, ingredientsDiffResults };
           break;
+        case GPDiffOptionsEnum.IMAGES:
+          const imageDiffResults = this.getImageDiff();
+          requestedFields = { ...requestedFields, imageDiffResults };
+          break;
       }
     }
     return requestedFields;
@@ -110,6 +115,12 @@ class DiffRecipes {
             ingredientsDiffResults,
           };
           break;
+        case GPDiffOptionsEnum.IMAGES:
+          const imageDiffResults = this.getImageNoDiff();
+          noDiffFieldResults = {
+            ...noDiffFieldResults,
+            imageDiffResults,
+          };
       }
     }
     return noDiffFieldResults;
@@ -122,7 +133,7 @@ class DiffRecipes {
   getCourseIngredientsDiff() {
     const diffIngredients = new DiffRecipeIngredients(
       this.recipeA.ingredients,
-      this.recipeB.ingredients,
+      this.recipeB.ingredients
     );
     const ingredinetsDiffResults =
       diffIngredients.getIngredientsComparisonDiff();
@@ -132,10 +143,35 @@ class DiffRecipes {
   getCourseInstrictionDiff() {
     const diffInstructions = new DiffRecipeStringArray(
       this.recipeA.instructions,
-      this.recipeB.instructions,
+      this.recipeB.instructions
     );
     const instructionsDiffResults = diffInstructions.getLcsDiff();
     return instructionsDiffResults;
+  }
+
+  /**
+   * Find the difference in images between the original and edited recipe
+   * @returns array containing the status between the original recipes images and the edited recipes images
+   */
+  getImageDiff() {
+    const diffImages = new DiffRecipeStringArray(
+      this.recipeA.previewImage,
+      this.recipeB.previewImage
+    );
+    const imageDiffResults = diffImages.getStringArrayDiff();
+    return imageDiffResults;
+  }
+
+  /**
+   * format the edited recipes images into diff format with unchanged status
+   * @returns array in the format of diff line info
+   */
+  getImageNoDiff() {
+    let imageNoDiffResults: GPDiffLineInfoType<string>[] = [];
+    for(const image of this.recipeB.previewImage) {
+      imageNoDiffResults = [...imageNoDiffResults, { status: DiffStatus.UNCHANGED, line: image}]
+    }
+    return imageNoDiffResults
   }
 
   /**
@@ -145,7 +181,7 @@ class DiffRecipes {
   getInstructionDiff() {
     const diffInstructions = new DiffRecipeStringArray(
       this.recipeA.instructions,
-      this.recipeB.instructions,
+      this.recipeB.instructions
     );
     const instructionsDiffResults = diffInstructions.getStringArrayDiff();
     return instructionsDiffResults;
@@ -173,7 +209,7 @@ class DiffRecipes {
   getIngredientsDiff() {
     const diffIngredients = new DiffRecipeIngredients(
       this.recipeA.ingredients,
-      this.recipeB.ingredients,
+      this.recipeB.ingredients
     );
     const ingredientsDiffResults = diffIngredients.getIngredientsDiff();
     return ingredientsDiffResults;
@@ -186,7 +222,7 @@ class DiffRecipes {
   getIngredientsNoDiff() {
     const diffIngredients = new DiffRecipeIngredients(
       this.recipeA.ingredients,
-      this.recipeA.ingredients,
+      this.recipeA.ingredients
     );
     const ingredientsDiffResults = diffIngredients.getIngredientsDiff();
     return ingredientsDiffResults;
@@ -199,7 +235,7 @@ class DiffRecipes {
   getTitleDiff() {
     const diffTitle = new DiffRecipeStringArray(
       [this.recipeA.recipeTitle],
-      [this.recipeB.recipeTitle],
+      [this.recipeB.recipeTitle]
     );
     const titleDiffResults = diffTitle.getStringArrayDiff();
     return titleDiffResults;
@@ -220,7 +256,7 @@ class DiffRecipes {
   getServingsDiff() {
     const diffServings = new DiffRecipeStringArray(
       [this.recipeA.servings.toString()],
-      [this.recipeB.servings.toString()],
+      [this.recipeB.servings.toString()]
     );
     const servingsDiffResults = diffServings.getStringArrayDiff();
     return servingsDiffResults;
@@ -241,7 +277,7 @@ class DiffRecipes {
   getTagDiff() {
     const diffTags = new DiffRecipeStringArray(
       this.recipeA.recipeTags,
-      this.recipeB.recipeTags,
+      this.recipeB.recipeTags
     );
     const tagsDiffResults = diffTags.getStringArrayDiff();
     return tagsDiffResults;
@@ -269,7 +305,7 @@ class DiffRecipes {
   getCookTimeDiff() {
     const diffCookTime = new DiffRecipeStringArray(
       [this.recipeA.readyInMinutes.toString()],
-      [this.recipeB.readyInMinutes.toString()],
+      [this.recipeB.readyInMinutes.toString()]
     );
     const cookTimeDiffResults = diffCookTime.getStringArrayDiff();
     return cookTimeDiffResults;

--- a/frontend/src/components/calendar/CalendarDisplay.tsx
+++ b/frontend/src/components/calendar/CalendarDisplay.tsx
@@ -37,7 +37,7 @@ const CalendarDisplay = ({ selectedRecipes }: GPUpcomingScheduleType) => {
                   borderRadius: "md",
                 }}
               >
-                {currentDay} {currentDayStart.getMonth()}/
+                {currentDay} {currentDayStart.getMonth() + 1}/
                 {currentDayStart.getDate()}
               </Typography>
               {scheduledRecipes
@@ -49,7 +49,7 @@ const CalendarDisplay = ({ selectedRecipes }: GPUpcomingScheduleType) => {
                 })
                 .map((eventInfo, index) => {
                   return (
-                    <Box key={index} sx={{ display: "flex", flexGrow: 1 }}>
+                    <Box key={index} sx={{ display: "flex", flexGrow: 1, my: 2 }}>
                       <MealCard
                         index={index}
                         toggleCalendarTimeModal={() => {}}

--- a/frontend/src/components/editRecipe/SubstitutionOption.tsx
+++ b/frontend/src/components/editRecipe/SubstitutionOption.tsx
@@ -9,10 +9,10 @@ import {
   Table,
   Typography,
 } from "@mui/joy";
-import type { IngredientSubstitutes } from "../../classes/ingredients/IngredientSubstitutes";
+import type { GPAiSubstitutionReturnType } from "../../utils/types/aiSubReturnType";
 
 type GPSubstitutionOptionType = {
-  optionData: IngredientSubstitutes;
+  optionData: GPAiSubstitutionReturnType;
 };
 
 const SubstitutionOption = ({ optionData }: GPSubstitutionOptionType) => {

--- a/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
+++ b/frontend/src/components/editRecipe/SubstitutionOptionsDropdown.tsx
@@ -7,15 +7,15 @@ import {
   Typography,
 } from "@mui/joy";
 import SubstitutionOption from "./SubstitutionOption";
-import type { IngredientSubstitutes } from "../../classes/ingredients/IngredientSubstitutes";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import type { IngredientData } from "../../../../shared/IngredientData";
+import type { GPAiSubstitutionReturnType } from "../../utils/types/aiSubReturnType";
 
 type GPSubstitutionOptionsType = {
   ingredientIndex: number;
   originalIngredient: IngredientData;
   onSubstitutionSelect: (
-    option: IngredientSubstitutes,
+    option: GPAiSubstitutionReturnType,
     index: number,
     originalIngredientName: string
   ) => void;
@@ -27,7 +27,7 @@ const SubstitutionOptionsDropdown = ({
   onSubstitutionSelect,
 }: GPSubstitutionOptionsType) => {
   const handleSelectSubstitution = (
-    option: IngredientSubstitutes,
+    option: GPAiSubstitutionReturnType,
     ingredientIndex: number
   ) => {
     onSubstitutionSelect(

--- a/frontend/src/components/recipeDiff/DiffOriginalRecipe.tsx
+++ b/frontend/src/components/recipeDiff/DiffOriginalRecipe.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import type { GPDiffLineInfoType } from "../../utils/diffUtils";
+import { DiffStatus, type GPDiffLineInfoType } from "../../utils/diffUtils";
 import {
   AspectRatio,
   List,
@@ -40,6 +40,7 @@ type GPOriginalRecipeDiffType = {
   cookTimeDiffResults?: GPDiffLineInfoType[];
   ingredientsDiffResults?: GPDiffLineInfoType[];
   instructionsDiffResults?: GPDiffLineInfoType[];
+  imageDiffResults?: GPDiffLineInfoType[];
 };
 
 const DiffOriginalRecipe = ({
@@ -64,7 +65,7 @@ const DiffOriginalRecipe = ({
       // otherwise diff only requested fields
       const recipeDiffInfo = recipeDiff.getRequestedDiff(
         userDiffChoices,
-        noDiffFields,
+        noDiffFields
       );
       setRecipeDiffInfo(recipeDiffInfo);
     }
@@ -86,10 +87,34 @@ const DiffOriginalRecipe = ({
         <ModalDialog layout="fullscreen">
           <ModalClose variant="plain" sx={{ zIndex: 2, m: 1 }} />
           <DialogContent sx={{ m: 4 }}>
+            <Box sx={{ display: "flex" }}>
+              {recipeDiffInfo?.imageDiffResults?.map((image, index) => {
+                console.log(image);
+                return (
+                  <AspectRatio
+                    key={index}
+                    ratio="1"
+                    sx={{
+                      ...(image.status === DiffStatus.ADDED ||
+                      image.status === DiffStatus.DELETED
+                        ? {
+                            border: 5,
+                            ...(image.status === DiffStatus.ADDED
+                              ? { borderColor: "success.200" }
+                              : { borderColor: "danger.200" }),
+                          }
+                        : {}),
+                      width: 350,
+                      borderRadius: "md",
+                      mx: 1,
+                    }}
+                  >
+                    <img src={image.line} />
+                  </AspectRatio>
+                );
+              })}
+            </Box>
             <Box sx={GPMealInfoModalTitleStyle}>
-              <AspectRatio ratio="1" sx={{ width: 350, borderRadius: "md" }}>
-                <img src={originalRecipeInfo.previewImage[0]} />
-              </AspectRatio>
               <Box sx={GPCenteredBoxStyle}>
                 {recipeDiffInfo?.titleDiffResults && (
                   <DiffOriginalContentDisplay
@@ -99,6 +124,12 @@ const DiffOriginalRecipe = ({
                     childComponentProps={{ level: "h2" }}
                   />
                 )}
+                <Typography level="h4">
+                  Original Creator: {editedRecipeInfo.originalSource}
+                </Typography>
+                <Typography level="h4">
+                  Edited By: {editedRecipeInfo.editingAuthorName}
+                </Typography>
                 <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
                   <Typography>Servings:</Typography>
                   {recipeDiffInfo?.servingsDiffResults && (

--- a/frontend/src/components/recipeDiff/DiffOriginalRecipe.tsx
+++ b/frontend/src/components/recipeDiff/DiffOriginalRecipe.tsx
@@ -88,9 +88,7 @@ const DiffOriginalRecipe = ({
           <ModalClose variant="plain" sx={{ zIndex: 2, m: 1 }} />
           <DialogContent sx={{ m: 4 }}>
             <Box sx={{ display: "flex" }}>
-              {recipeDiffInfo?.imageDiffResults?.map((image, index) => {
-                console.log(image);
-                return (
+              {recipeDiffInfo?.imageDiffResults?.map((image, index) => 
                   <AspectRatio
                     key={index}
                     ratio="1"
@@ -111,8 +109,7 @@ const DiffOriginalRecipe = ({
                   >
                     <img src={image.line} />
                   </AspectRatio>
-                );
-              })}
+              )}
             </Box>
             <Box sx={GPMealInfoModalTitleStyle}>
               <Box sx={GPCenteredBoxStyle}>


### PR DESCRIPTION
## Description

<what this pull request is doing>

- enable a user to view the diff between the original recipes images and the edited recipes images via outline

<what will be done in later PRs and not included here>

- possibly use a tint over the image to show the diff

## Milestones

<the milestones or stories/features that this works towards>

- finishing touches on app

## Resources

<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>

## Test Plan

<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>
<img width="1406" height="862" alt="Screenshot 2025-07-30 at 5 18 28 PM" src="https://github.com/user-attachments/assets/79092655-bc78-44cb-8c18-7c620767345a" />
